### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/polyfill": "^7.2.5",
     "@clerk/backend": "^3.2.4",
     "@clerk/clerk-react": "^5.61.3",
+    "@vercel/analytics": "^2.0.1",
     "axios": "^1.7.0",
     "bootstrap": "^3.4.1",
     "classnames": "^2.2.6",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { ClerkProvider } from '@clerk/clerk-react'
+import { Analytics } from '@vercel/analytics/react'
 
 import { ConfigProvider } from './components/config/context/ConfigProvider'
 import { App } from './components/App'
@@ -42,6 +43,7 @@ window.onload = () => {
       <ConfigProvider>
         <App />
       </ConfigProvider>
+      <Analytics />
     </ClerkProvider>
   )
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,9 +43,11 @@ module.exports = {
             ]
           }
         },
-        // Transpile @clerk/* (optional chaining); skip other node_modules
+        // Transpile @clerk/* (optional chaining), @vercel/analytics (?? / modern syntax); skip other node_modules
         exclude: (modulePath) =>
-          /node_modules/.test(modulePath) && !/node_modules[\\/]@clerk/.test(modulePath)
+          /node_modules/.test(modulePath) &&
+          !/node_modules[\\/]@clerk/.test(modulePath) &&
+          !/node_modules[\\/]@vercel[\\/]analytics/.test(modulePath)
       },
       {
         test: /\.(css|less)$/,
@@ -90,6 +92,13 @@ module.exports = {
   // resolves directory to look for modules and resolves extensions
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs'],
-    modules: ['node_modules']
+    modules: ['node_modules'],
+    // Webpack 4 ignores package "exports"; @vercel/analytics only exposes ./react via exports
+    alias: {
+      '@vercel/analytics/react': path.join(
+        __dirname,
+        'node_modules/@vercel/analytics/dist/react/index.js'
+      ),
+    },
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,11 @@
     "@typescript-eslint/types" "8.57.2"
     eslint-visitor-keys "^5.0.0"
 
+"@vercel/analytics@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-2.0.1.tgz#d7d7bd37af7cfbeea95db5f132ae4889f4d26407"
+  integrity sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==
+
 "@vercel/build-utils@13.12.2":
   version "13.12.2"
   resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-13.12.2.tgz#5df7ce16e868feb5e9e0988cf8e3681efb3f1d70"


### PR DESCRIPTION
Adds [`@vercel/analytics/react`](https://vercel.com/docs/analytics) with a `<Analytics />` component in `src/index.tsx` (inside `ClerkProvider`).

**Webpack 4:** the package only exposes `@vercel/analytics/react` via `package.json` `exports`, which webpack 4 does not resolve, so this PR adds a `resolve.alias` to `dist/react/index.js`. The analytics bundle also uses syntax (e.g. nullish coalescing) that needs Babel, so `@vercel/analytics` is included alongside `@clerk` for transpilation.

Enable Web Analytics for the project in the Vercel dashboard if it is not already on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated analytics into the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->