### PR TITLE
fix(presets): mark premium presets in All tab and cancel trial on free select

### DIFF
--- a/src/components/presets/Presets.css
+++ b/src/components/presets/Presets.css
@@ -165,6 +165,20 @@
   border-color: #999;
 }
 
+.preset-item--premium {
+  border: 1px solid transparent;
+  background-image:
+    linear-gradient(#111, #111),
+    linear-gradient(var(--premium-tab-angle), #ff6b6b, #ffd93d, #6bcb77, #4d96ff, #c77dff, #ff6b6b);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  animation: premium-tab-rotate 3s linear infinite;
+}
+
+.preset-item--premium:hover {
+  color: #eee;
+}
+
 .preset-trial-countdown {
   position: absolute;
   inset: 0;

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -32,7 +32,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
 
   const packMap = new Map(packs.map(p => [p.name, p]))
 
-  const { startTrial, modalVisible, trialPackName, secondsLeft, dismissTrial } = usePremiumTrial({
+  const { startTrial, cancelTrial, modalVisible, trialPackName, secondsLeft, dismissTrial } = usePremiumTrial({
     config,
     revertConfig,
     retrieveConfigPreset,
@@ -65,6 +65,8 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
       setTrialPresetKey(preset.id ?? preset.name)
       startTrial(preset.pack, event)
     } else {
+      cancelTrial()
+      setTrialPresetKey(null)
       void retrieveConfigPreset(event)
     }
     onSelect?.({ name: preset.name, label: preset.label, pack: preset.pack, isOwn: preset.isOwn })
@@ -109,10 +111,12 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
                 currentTarget: { dataset: { name: String(name), id: id ?? '' } },
               }
               const isTrialing = trialPresetKey === (id ?? name) && secondsLeft !== null
+              const presetPackMeta = packMap.get(preset.pack)
+              const isPremiumUnowned = presetPackMeta?.isPremium && !presetPackMeta.isOwn
               return (
                 <button
                   key={id ?? name}
-                  className='preset-item'
+                  className={`preset-item${isPremiumUnowned ? ' preset-item--premium' : ''}`}
                   data-name={name}
                   data-id={id ?? ''}
                   onClick={() => handlePresetClick(preset, event)}

--- a/src/components/presets/usePremiumTrial.ts
+++ b/src/components/presets/usePremiumTrial.ts
@@ -48,6 +48,13 @@ export const usePremiumTrial = ({ config, revertConfig, retrieveConfigPreset }: 
     }, TRIAL_DURATION_S * 1000)
   }, [config, retrieveConfigPreset, clearTrial])
 
+  const cancelTrial = useCallback(() => {
+    clearTrial()
+    setSecondsLeft(null)
+    setTrialPackName('')
+    snapshotRef.current = null
+  }, [clearTrial])
+
   const dismissTrial = useCallback(() => {
     clearTrial()
     setModalVisible(false)
@@ -60,5 +67,5 @@ export const usePremiumTrial = ({ config, revertConfig, retrieveConfigPreset }: 
 
   useEffect(() => () => clearTrial(), [clearTrial])
 
-  return { startTrial, modalVisible, trialPackName, secondsLeft, dismissTrial }
+  return { startTrial, cancelTrial, modalVisible, trialPackName, secondsLeft, dismissTrial }
 }


### PR DESCRIPTION
## Summary

- Premium presets in the **All** tab now show the same animated rainbow border as premium pack tabs, so users can distinguish them before clicking
- Clicking a non-premium preset while a trial countdown is active now cancels the trial (clears timers, resets countdown) without reverting config — previously the 30s counter kept running in the background

## Test plan

- [ ] Switch to All tab — verify premium presets have the rainbow border
- [ ] Click a premium preset, confirm countdown starts
- [ ] Click a free preset mid-countdown — confirm countdown stops and no paywall modal fires
- [ ] Click a premium preset, let it run to 0 — confirm paywall modal still fires correctly
- [ ] Subscribed user: confirm no rainbow border on their owned premium presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to cancel active premium trials at any time.

* **Style**
  * Premium preset items now feature animated gradient border effects for enhanced visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->