### PR TITLE
fix(api): run actual db ping to keep Atlas cluster alive

### DIFF
--- a/api/ping.ts
+++ b/api/ping.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { connectDB } from '../server/db'
 
 export default async (_req: VercelRequest, res: VercelResponse): Promise<void> => {
-  await connectDB()
+  const db = await connectDB()
+  await db.connection.db.command({ ping: 1 })
   res.status(200).json({ ok: true })
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "."
+  },
+  "include": ["./**/*", "../server/**/*"]
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -5,8 +5,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strict": true,
-    "outDir": "."
-  },
-  "include": ["./**/*", "../server/**/*"]
+    "strict": true
+  }
 }


### PR DESCRIPTION
## Summary

- `connectDB` caches the mongoose connection on `globalThis`, so warm Vercel containers returned early without ever touching Atlas — causing the cluster to appear inactive and eventually get paused
- Added `db.connection.db.command({ ping: 1 })` after connecting to guarantee a round-trip on every cron invocation regardless of connection cache state
- Added `api/tsconfig.json` with `"module": "CommonJS"` so Vercel compiles the serverless function correctly — previously it was emitting bare ESM that Node.js rejected at runtime

## Test plan

- [ ] Deploy and confirm `/api/ping` returns `{ ok: true }` without a 500
- [ ] Verify Atlas shows recent activity after the endpoint is hit
- [ ] Confirm Vercel cron continues to fire on schedule and resets the 30-day inactivity timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the API health check to verify database connectivity by issuing a live ping before reporting success.

* **Chores**
  * Added TypeScript configuration for API code to improve compilation consistency and strict type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->