### PR TITLE
feat: move particle storage to Cloudflare R2

### DIFF
--- a/api/uploadParticle.ts
+++ b/api/uploadParticle.ts
@@ -1,13 +1,27 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { uploadParticleHandler } from '../server/routes/uploadParticleHandler'
+import { MAX_UPLOAD_BYTES, uploadParticleHandler } from '../server/routes/uploadParticleHandler'
 
 // Vercel's default JSON/urlencoded body parser doesn't apply to raw image uploads.
 export const config = { api: { bodyParser: false } }
 
-const readRawBody = (req: VercelRequest): Promise<Buffer> =>
+class PayloadTooLargeError extends Error {}
+
+// Unlike server/dev.ts (which gets this for free from express.raw({ limit })), Vercel's raw
+// stream has no built-in size cap -- without one, an oversized request buffers fully in memory
+// before uploadParticleHandler ever gets a chance to check MAX_UPLOAD_BYTES.
+const readRawBody = (req: VercelRequest, maxBytes: number): Promise<Buffer> =>
   new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    let receivedBytes = 0
+    req.on('data', (chunk: Buffer) => {
+      receivedBytes += chunk.length
+      if (receivedBytes > maxBytes) {
+        req.destroy()
+        reject(new PayloadTooLargeError())
+        return
+      }
+      chunks.push(chunk)
+    })
     req.on('end', () => resolve(Buffer.concat(chunks)))
     req.on('error', reject)
   })
@@ -17,6 +31,15 @@ export default async (req: VercelRequest, res: VercelResponse): Promise<void> =>
     res.status(405).json({ error: 'Method not allowed' })
     return
   }
-  const body = await readRawBody(req)
+  let body: Buffer
+  try {
+    body = await readRawBody(req, MAX_UPLOAD_BYTES)
+  } catch (err) {
+    if (err instanceof PayloadTooLargeError) {
+      res.status(413).json({ error: `Image exceeds max size of ${MAX_UPLOAD_BYTES} bytes` })
+      return
+    }
+    throw err
+  }
   return uploadParticleHandler({ ...req, body } as never, res as never)
 }

--- a/api/uploadParticle.ts
+++ b/api/uploadParticle.ts
@@ -1,0 +1,22 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { uploadParticleHandler } from '../server/routes/uploadParticleHandler'
+
+// Vercel's default JSON/urlencoded body parser doesn't apply to raw image uploads.
+export const config = { api: { bodyParser: false } }
+
+const readRawBody = (req: VercelRequest): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks)))
+    req.on('error', reject)
+  })
+
+export default async (req: VercelRequest, res: VercelResponse): Promise<void> => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+  const body = await readRawBody(req)
+  return uploadParticleHandler({ ...req, body } as never, res as never)
+}

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "dev": "concurrently --kill-others \"yarn server-dev\" \"yarn client-dev\"",
     "lint": "eslint src --fix",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "seed": "node scripts/seed-presets.js",
-    "seed-packs": "node scripts/seed-packs.js"
+    "seed-packs": "node scripts/seed-packs.js",
+    "migrate-particles-to-r2": "node scripts/migrate-particles-to-r2.js"
   },
   "author": "Cody Douglass",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1101.0",
     "@babel/polyfill": "^7.2.5",
     "@clerk/backend": "^3.2.14",
     "@clerk/clerk-react": "^5.61.3",
@@ -25,6 +28,7 @@
     "bootstrap": "^3.4.1",
     "classnames": "^2.2.6",
     "dotenv": "^17.4.0",
+    "image-size": "^2.0.2",
     "mongoose": "^9.7.2",
     "postprocessing": "6.29.3",
     "react": "^18.2.0",
@@ -59,6 +63,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
     "@vercel/node": "^5.7.0",
+    "@webpack-cli/serve": "^2.0.0",
     "autoprefixer": "^10.4.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^9.0.0",
@@ -79,8 +84,7 @@
     "vitest": "^4.1.4",
     "webpack": "^5.0.0",
     "webpack-cli": "^5.0.0",
-    "webpack-dev-server": "^5.2.6",
-    "@webpack-cli/serve": "^2.0.0"
+    "webpack-dev-server": "^5.2.6"
   },
   "repository": {
     "type": "git",

--- a/scripts/migrate-particles-to-r2.js
+++ b/scripts/migrate-particles-to-r2.js
@@ -1,0 +1,64 @@
+// Uploads the built-in particle sprite PNGs referenced by src/config/presets.ts (plus
+// BUILTIN_PARTICLE_SPRITES) from public/ up to R2, under the `builtins/` prefix.
+// Idempotent: skips any key that's already present in the bucket.
+require('dotenv').config()
+require('@babel/register')({
+  extensions: ['.ts'],
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-typescript',
+  ],
+})
+
+const fs = require('fs')
+const path = require('path')
+const { storageService } = require('../server/services/StorageService.ts')
+const { presets } = require('../src/config/presets.ts')
+const { BUILTIN_PARTICLE_SPRITES } = require('../src/config/particle.config.ts')
+
+const PUBLIC_DIR = path.join(__dirname, '../public')
+
+// Bundled presets reference sprites by bare filename (e.g. 'galaxySprite.png') anywhere
+// inside their config tree — walk every value to find them, rather than hardcoding a list.
+const collectReferencedPngs = (value, out) => {
+  if (typeof value === 'string') {
+    if (/^[A-Za-z0-9_.-]+\.png$/.test(value)) out.add(value)
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v) => collectReferencedPngs(v, out))
+    return
+  }
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach((v) => collectReferencedPngs(v, out))
+  }
+}
+
+const findBuiltinPngs = () => {
+  const out = new Set(BUILTIN_PARTICLE_SPRITES)
+  collectReferencedPngs(presets, out)
+  return [...out].filter((name) => fs.existsSync(path.join(PUBLIC_DIR, name)))
+}
+
+const migrate = async () => {
+  const filenames = findBuiltinPngs()
+  console.info(`Found ${filenames.length} built-in particle sprites to migrate`)
+
+  for (const filename of filenames) {
+    const key = `builtins/${filename}`
+    if (await storageService.objectExists(key)) {
+      console.info(`Skipping (already in R2): ${filename}`)
+      continue
+    }
+    const body = fs.readFileSync(path.join(PUBLIC_DIR, filename))
+    const url = await storageService.putObject(key, body, 'image/png')
+    console.info(`Uploaded: ${filename} -> ${url}`)
+  }
+
+  console.info('Done')
+}
+
+migrate().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/server/dev.ts
+++ b/server/dev.ts
@@ -7,6 +7,7 @@ import { savePresetHandler } from './routes/savePresetHandler'
 import { packsHandler } from './routes/packsHandler'
 import { myPacksHandler } from './routes/myPacksHandler'
 import { createPackHandler } from './routes/createPackHandler'
+import { uploadParticleHandler, MAX_UPLOAD_BYTES } from './routes/uploadParticleHandler'
 
 const BUILD_DIR = path.join(__dirname, '../public/')
 
@@ -21,6 +22,7 @@ app.post('/api/savePreset', savePresetHandler)
 app.get('/api/packs', packsHandler)
 app.get('/api/packs/mine', myPacksHandler)
 app.post('/api/pack', createPackHandler)
+app.post('/api/uploadParticle', express.raw({ type: 'image/*', limit: MAX_UPLOAD_BYTES }), uploadParticleHandler)
 
 connectDB()
   .then(() => app.listen(8080, () => console.info('Listening on port 8080!')))

--- a/server/env.ts
+++ b/server/env.ts
@@ -2,6 +2,11 @@ export const env = {
   MONGO_URI: process.env.MONGO_URI,
   CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
   NODE_ENV: process.env.NODE_ENV ?? 'development',
+  R2_ACCOUNT_ID: process.env.R2_ACCOUNT_ID,
+  R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+  R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
+  R2_PUBLIC_URL: process.env.R2_PUBLIC_URL,
 }
 
 export const requireEnv = {
@@ -12,5 +17,25 @@ export const requireEnv = {
   CLERK_SECRET_KEY: (): string => {
     if (!env.CLERK_SECRET_KEY) throw new Error('CLERK_SECRET_KEY is required but not set')
     return env.CLERK_SECRET_KEY
+  },
+  R2_ACCOUNT_ID: (): string => {
+    if (!env.R2_ACCOUNT_ID) throw new Error('R2_ACCOUNT_ID is required but not set')
+    return env.R2_ACCOUNT_ID
+  },
+  R2_ACCESS_KEY_ID: (): string => {
+    if (!env.R2_ACCESS_KEY_ID) throw new Error('R2_ACCESS_KEY_ID is required but not set')
+    return env.R2_ACCESS_KEY_ID
+  },
+  R2_SECRET_ACCESS_KEY: (): string => {
+    if (!env.R2_SECRET_ACCESS_KEY) throw new Error('R2_SECRET_ACCESS_KEY is required but not set')
+    return env.R2_SECRET_ACCESS_KEY
+  },
+  R2_BUCKET_NAME: (): string => {
+    if (!env.R2_BUCKET_NAME) throw new Error('R2_BUCKET_NAME is required but not set')
+    return env.R2_BUCKET_NAME
+  },
+  R2_PUBLIC_URL: (): string => {
+    if (!env.R2_PUBLIC_URL) throw new Error('R2_PUBLIC_URL is required but not set')
+    return env.R2_PUBLIC_URL
   },
 }

--- a/server/routes/uploadParticleHandler.test.ts
+++ b/server/routes/uploadParticleHandler.test.ts
@@ -1,0 +1,110 @@
+import type { Request, Response } from 'express'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AuthUnauthorizedError, verifyAuth } from '../auth'
+import { storageService } from '../services/StorageService'
+import { imageSize } from 'image-size'
+import { uploadParticleHandler, MAX_UPLOAD_BYTES, MAX_DECODED_DIMENSION_PX } from './uploadParticleHandler'
+
+// vi.mock calls are hoisted above these imports, so the imports above already resolve to the mocks.
+vi.mock('../auth', () => ({
+  AuthUnauthorizedError: class AuthUnauthorizedError extends Error {},
+  verifyAuth: vi.fn(),
+}))
+vi.mock('../services/StorageService', () => ({
+  storageService: {
+    objectExists: vi.fn(),
+    putObject: vi.fn(),
+  },
+}))
+vi.mock('image-size', () => ({
+  imageSize: vi.fn(),
+}))
+
+const makeRes = (): Response & { statusCode: number; body: unknown } => {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code
+      return res
+    },
+    json(body: unknown) {
+      res.body = body
+      return res
+    },
+  }
+  return res as unknown as Response & { statusCode: number; body: unknown }
+}
+
+const makeReq = (body: unknown, authorization = 'Bearer valid-token'): Request =>
+  ({ headers: { authorization }, body }) as unknown as Request
+
+describe('uploadParticleHandler', () => {
+  beforeEach(() => {
+    vi.mocked(verifyAuth).mockReset().mockResolvedValue('user_123')
+    vi.mocked(storageService.objectExists).mockReset().mockResolvedValue(false)
+    vi.mocked(storageService.putObject).mockReset().mockResolvedValue('https://cdn.example.com/particles/user_123/key.png')
+    vi.mocked(imageSize).mockReset().mockReturnValue({ width: 64, height: 64, type: 'png' })
+  })
+
+  it('rejects when unauthenticated', async () => {
+    vi.mocked(verifyAuth).mockRejectedValueOnce(new AuthUnauthorizedError())
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('x')), res)
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects a non-buffer body', async () => {
+    const res = makeRes()
+    await uploadParticleHandler(makeReq('not-a-buffer'), res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects a body over the max byte size', async () => {
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.alloc(MAX_UPLOAD_BYTES + 1)), res)
+    expect(res.statusCode).toBe(413)
+  })
+
+  it('rejects an undecodable image', async () => {
+    vi.mocked(imageSize).mockImplementationOnce(() => {
+      throw new Error('unrecognized format')
+    })
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('garbage')), res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects a format outside the allowlist', async () => {
+    vi.mocked(imageSize).mockReturnValueOnce({ width: 64, height: 64, type: 'bmp' })
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('bmp-bytes')), res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects dimensions over the max decoded pixel size', async () => {
+    vi.mocked(imageSize).mockReturnValueOnce({ width: MAX_DECODED_DIMENSION_PX + 1, height: 64, type: 'png' })
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('big-image')), res)
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects an overwrite of an existing key', async () => {
+    vi.mocked(storageService.objectExists).mockResolvedValueOnce(true)
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('valid-png-bytes')), res)
+    expect(res.statusCode).toBe(409)
+  })
+
+  it('uploads a valid image scoped to the authenticated user and returns its URL', async () => {
+    const res = makeRes()
+    await uploadParticleHandler(makeReq(Buffer.from('valid-png-bytes')), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ url: 'https://cdn.example.com/particles/user_123/key.png' })
+
+    const [key, , contentType] = vi.mocked(storageService.putObject).mock.calls[0]!
+    expect(key).toMatch(/^particles\/user_123\/[0-9a-f-]+\.png$/)
+    expect(contentType).toBe('image/png')
+  })
+})

--- a/server/routes/uploadParticleHandler.ts
+++ b/server/routes/uploadParticleHandler.ts
@@ -1,0 +1,81 @@
+import type { Request, Response } from 'express'
+import crypto from 'crypto'
+import { imageSize } from 'image-size'
+import { AuthUnauthorizedError, verifyAuth } from '../auth'
+import { storageService } from '../services/StorageService'
+
+// Mirrors ParticleSpriteHud's client-side MAX_DATA_URL_BYTES — client checks are
+// supplementary only, this is the real boundary.
+export const MAX_UPLOAD_BYTES = 2 * 1024 * 1024
+// Well above the 512px client resize target; just a hard ceiling against decompression-bomb-style images.
+export const MAX_DECODED_DIMENSION_PX = 4096
+
+const ALLOWED_FORMATS: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  webp: 'image/webp',
+  gif: 'image/gif',
+}
+
+export const uploadParticleHandler = async (req: Request, res: Response): Promise<void> => {
+  let userId: string
+  try {
+    userId = await verifyAuth(req.headers.authorization)
+  } catch (err) {
+    if (err instanceof AuthUnauthorizedError) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    console.error('auth failed:', err)
+    res.status(500).json({ error: 'Internal server error' })
+    return
+  }
+
+  const body = req.body
+  if (!Buffer.isBuffer(body) || body.length === 0) {
+    res.status(400).json({ error: 'Request body must be raw image bytes' })
+    return
+  }
+  if (body.length > MAX_UPLOAD_BYTES) {
+    res.status(413).json({ error: `Image exceeds max size of ${MAX_UPLOAD_BYTES} bytes` })
+    return
+  }
+
+  let format: string | undefined
+  let width: number | undefined
+  let height: number | undefined
+  try {
+    const decoded = imageSize(body)
+    format = decoded.type
+    width = decoded.width
+    height = decoded.height
+  } catch {
+    res.status(400).json({ error: 'Could not decode image' })
+    return
+  }
+
+  if (!format || !ALLOWED_FORMATS[format]) {
+    res.status(400).json({ error: 'Unsupported image format' })
+    return
+  }
+  if (!width || !height || width > MAX_DECODED_DIMENSION_PX || height > MAX_DECODED_DIMENSION_PX) {
+    res.status(400).json({ error: `Image dimensions exceed ${MAX_DECODED_DIMENSION_PX}px` })
+    return
+  }
+
+  const key = `particles/${userId}/${crypto.randomUUID()}.${format}`
+
+  // UUID collision is practically unreachable, but the endpoint must never silently overwrite a key.
+  if (await storageService.objectExists(key)) {
+    res.status(409).json({ error: 'Object already exists' })
+    return
+  }
+
+  try {
+    const url = await storageService.putObject(key, body, ALLOWED_FORMATS[format])
+    res.status(200).json({ url })
+  } catch (err) {
+    console.error('Failed to upload particle to R2', err)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}

--- a/server/routes/uploadParticleHandler.ts
+++ b/server/routes/uploadParticleHandler.ts
@@ -65,13 +65,12 @@ export const uploadParticleHandler = async (req: Request, res: Response): Promis
 
   const key = `particles/${userId}/${crypto.randomUUID()}.${format}`
 
-  // UUID collision is practically unreachable, but the endpoint must never silently overwrite a key.
-  if (await storageService.objectExists(key)) {
-    res.status(409).json({ error: 'Object already exists' })
-    return
-  }
-
   try {
+    // UUID collision is practically unreachable, but the endpoint must never silently overwrite a key.
+    if (await storageService.objectExists(key)) {
+      res.status(409).json({ error: 'Object already exists' })
+      return
+    }
     const url = await storageService.putObject(key, body, ALLOWED_FORMATS[format])
     res.status(200).json({ url })
   } catch (err) {

--- a/server/services/StorageService.ts
+++ b/server/services/StorageService.ts
@@ -1,0 +1,51 @@
+import { S3Client, PutObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3'
+import { requireEnv } from '../env'
+
+// Particles served from R2 are content-addressed / never overwritten in place, so
+// they're safe to cache forever on both R2's edge and the client.
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+
+let client: S3Client | null = null
+
+const getClient = (): S3Client => {
+  if (client) return client
+  client = new S3Client({
+    region: 'auto',
+    endpoint: `https://${requireEnv.R2_ACCOUNT_ID()}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv.R2_ACCESS_KEY_ID(),
+      secretAccessKey: requireEnv.R2_SECRET_ACCESS_KEY(),
+    },
+  })
+  return client
+}
+
+export class StorageService {
+  async objectExists(key: string): Promise<boolean> {
+    try {
+      await getClient().send(new HeadObjectCommand({ Bucket: requireEnv.R2_BUCKET_NAME(), Key: key }))
+      return true
+    } catch (err: unknown) {
+      const name = (err as { name?: string })?.name
+      if (name === 'NotFound' || name === 'NoSuchKey') return false
+      throw err
+    }
+  }
+
+  async putObject(key: string, body: Buffer, contentType: string): Promise<string> {
+    await getClient().send(new PutObjectCommand({
+      Bucket: requireEnv.R2_BUCKET_NAME(),
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      CacheControl: IMMUTABLE_CACHE_CONTROL,
+    }))
+    return this.buildPublicUrl(key)
+  }
+
+  buildPublicUrl(key: string): string {
+    return `${requireEnv.R2_PUBLIC_URL().replace(/\/+$/, '')}/${key}`
+  }
+}
+
+export const storageService = new StorageService()

--- a/src/components/config/ConfigWindow.tsx
+++ b/src/components/config/ConfigWindow.tsx
@@ -26,6 +26,7 @@ const ExternalWindowBridge = ({
   savePreset,
   isSignedIn,
   currentUserId,
+  getToken,
   presets,
   packs,
 }: ExternalWindowBridgeProps): React.ReactElement => {
@@ -43,6 +44,7 @@ const ExternalWindowBridge = ({
         savePreset,
         isSignedIn,
         currentUserId,
+        getToken,
         presets,
         packs,
       }}
@@ -114,6 +116,7 @@ const ConfigWindowInner = ({
   savePreset,
   isSignedIn,
   currentUserId,
+  getToken,
   presets,
   packs,
   onClose,
@@ -158,6 +161,7 @@ const ConfigWindowInner = ({
         savePreset={savePreset}
         isSignedIn={isSignedIn}
         currentUserId={currentUserId}
+        getToken={getToken}
         presets={presets}
         packs={packs}
       />
@@ -172,6 +176,7 @@ const ConfigWindowInner = ({
     savePreset,
     isSignedIn,
     currentUserId,
+    getToken,
     presets,
   ])
 

--- a/src/components/config/context/ConfigProvider.tsx
+++ b/src/components/config/context/ConfigProvider.tsx
@@ -5,6 +5,7 @@ import { useAuth, useUser } from '@clerk/clerk-react'
 import { AppConfig, ConfigItem, ParticleConfigSection, configDefaults } from '../../../config/configDefaults'
 import { particleConfig } from '../../../config/particle.config'
 import { presets } from '../../../config/presets'
+import { warmSpriteCache } from '../../../utils/spriteCache'
 
 export type PresetRetrieveEvent = {
   currentTarget: { dataset: { [key: string]: string | undefined } }
@@ -150,6 +151,10 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
   const [packList, setPackList] = useState<PackMeta[]>([])
 
   useEffect(() => {
+    void warmSpriteCache(configDefaults.particle.sprites.value)
+  }, [])
+
+  useEffect(() => {
     if (!localStorage.getItem('presets')) {
       localStorage.setItem('presets', JSON.stringify(
         Object.fromEntries(Object.entries(presets).map(([k, v]) => [k, v.config]))
@@ -243,6 +248,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
       const pad = configDefaults.particle.sprites.value[0] ?? 'fractaleye.png'
       next = [...next, ...Array(spritesMin - next.length).fill(pad)].slice(0, spritesMax)
     }
+    void warmSpriteCache(next)
     setConfig((prev) => {
       const n = {
         ...prev,
@@ -323,6 +329,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
     const next = normalizeLoadedPreset(cfg)
     setConfig(next)
     window.config = next
+    void warmSpriteCache(next.particle.sprites.value)
     const sameClips =
       prevClips.length === next.video.clips.length &&
       prevClips.every((c, i) => c === next.video.clips[i])

--- a/src/components/config/context/ConfigProvider.tsx
+++ b/src/components/config/context/ConfigProvider.tsx
@@ -125,6 +125,7 @@ export type ConfigContextValue = {
   savePreset: (name: string, pack: string, force?: boolean) => Promise<void>
   isSignedIn: boolean
   currentUserId: string | null
+  getToken: () => Promise<string | null>
   presets: PresetMeta[]
   packs: PackMeta[]
 }
@@ -369,7 +370,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
   }, [config, getToken])
 
   return (
-    <ConfigContext.Provider value={{ config, updateConfigItem, updateVideoClips, updateParticleSprites, retrieveConfigPreset, revertConfig, resetConfig, savePreset, isSignedIn: isSignedIn ?? false, currentUserId: user?.id ?? null, presets: presetList, packs: packList }}>
+    <ConfigContext.Provider value={{ config, updateConfigItem, updateVideoClips, updateParticleSprites, retrieveConfigPreset, revertConfig, resetConfig, savePreset, isSignedIn: isSignedIn ?? false, currentUserId: user?.id ?? null, getToken, presets: presetList, packs: packList }}>
       {children}
     </ConfigContext.Provider>
   )

--- a/src/components/config/context/ConfigProvider.tsx
+++ b/src/components/config/context/ConfigProvider.tsx
@@ -118,7 +118,7 @@ export type ConfigContextValue = {
   config: AppConfig
   updateConfigItem: (category: string, item: string, value: string | boolean | number) => void
   updateVideoClips: (clips: string[]) => void
-  updateParticleSprites: (sprites: string[]) => void
+  updateParticleSprites: (sprites: string[]) => Promise<void>
   retrieveConfigPreset: (event: PresetRetrieveEvent) => Promise<void>
   revertConfig: (snapshot: AppConfig) => void
   resetConfig: () => void
@@ -241,7 +241,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
     }
   }, [])
 
-  const updateParticleSprites = useCallback((sprites: string[]) => {
+  const updateParticleSprites = useCallback(async (sprites: string[]) => {
     const { sprites_MIN: spritesMin, sprites_MAX: spritesMax } = particleConfig
     const deduped = [...new Set(sprites)].slice(0, spritesMax)
     let next = deduped
@@ -249,7 +249,10 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
       const pad = configDefaults.particle.sprites.value[0] ?? 'fractaleye.png'
       next = [...next, ...Array(spritesMin - next.length).fill(pad)].slice(0, spritesMax)
     }
-    void warmSpriteCache(next)
+    // Wait for the cache to warm before the particle system rebuild (triggered by the
+    // window.config write below) can fire on the next frame -- otherwise a not-yet-cached
+    // sprite races a cold cross-origin TextureLoader load against this same fetch.
+    await warmSpriteCache(next)
     setConfig((prev) => {
       const n = {
         ...prev,
@@ -328,9 +331,11 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
 
     const prevClips = window.config.video.clips
     const next = normalizeLoadedPreset(cfg)
+    // Same reasoning as updateParticleSprites: warm the cache before the config write triggers
+    // a rebuild, so a preset's not-yet-cached sprites don't race a cold cross-origin load.
+    await warmSpriteCache(next.particle.sprites.value)
     setConfig(next)
     window.config = next
-    void warmSpriteCache(next.particle.sprites.value)
     const sameClips =
       prevClips.length === next.video.clips.length &&
       prevClips.every((c, i) => c === next.video.clips[i])

--- a/src/components/huds/ParticleSpriteHud.css
+++ b/src/components/huds/ParticleSpriteHud.css
@@ -138,7 +138,7 @@
   transition: border-color 0.15s ease, color 0.15s ease;
 }
 
-.particle-sprite-hud__upload-label:hover {
+.particle-sprite-hud__upload-label:hover:not(.particle-sprite-hud__upload-label--disabled) {
   border-color: #004400;
   color: #ccc;
 }
@@ -146,7 +146,6 @@
 .particle-sprite-hud__upload-label--disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 .particle-sprite-hud__upload input {
@@ -155,4 +154,11 @@
   height: 0;
   opacity: 0;
   pointer-events: none;
+}
+
+.particle-sprite-hud__upload-error {
+  font-size: 10px;
+  line-height: 1.3;
+  color: #e08080;
+  text-align: center;
 }

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -58,7 +58,7 @@ const spriteLabel = (src: string): string => {
 
 type ParticleSpriteHudProps = {
   config: AppConfig
-  updateParticleSprites: (sprites: string[]) => void
+  updateParticleSprites: (sprites: string[]) => Promise<void>
   isSignedIn: boolean
   getToken: () => Promise<string | null>
 }
@@ -79,7 +79,7 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
 
   const setSprites = useCallback(
     (next: string[]) => {
-      updateParticleSprites(next)
+      void updateParticleSprites(next)
     },
     [updateParticleSprites],
   )
@@ -149,6 +149,9 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
             const { data } = await axios.post<{ url: string }>('/api/uploadParticle', blob, {
               headers: { Authorization: `Bearer ${token}`, 'Content-Type': blob.type || 'image/png' },
             })
+            // setSprites -> updateParticleSprites awaits the sprite cache warming before
+            // updating the live config, so the particle system rebuild it triggers resolves
+            // straight to the cached blob: URL instead of racing a cold cross-origin fetch.
             setSprites([...spritesRef.current, data.url])
           } catch {
             showUploadError('Could not upload this image.')

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef } from 'react'
 import axios from 'axios'
-import { useAuth } from '@clerk/clerk-react'
 import './ParticleSpriteHud.css'
 
 import { connectConfig } from '../config/context/ConfigProvider'
@@ -59,10 +58,11 @@ const spriteLabel = (src: string): string => {
 type ParticleSpriteHudProps = {
   config: AppConfig
   updateParticleSprites: (sprites: string[]) => void
+  isSignedIn: boolean
+  getToken: () => Promise<string | null>
 }
 
-const ParticleSpriteHudInner = ({ config, updateParticleSprites }: ParticleSpriteHudProps): React.ReactElement => {
-  const { isSignedIn, getToken } = useAuth()
+const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, getToken }: ParticleSpriteHudProps): React.ReactElement => {
   const sprites = config.particle.sprites.value
   const spritesRef = useRef(sprites)
   spritesRef.current = sprites

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import axios from 'axios'
 import './ParticleSpriteHud.css'
 
@@ -11,6 +11,7 @@ import { presetSpriteSrc } from '../../utils/presetSpriteSrc'
 // these client-side checks only save a round trip, the server enforces its own limits independently.
 const MAX_DATA_URL_BYTES = 2 * 1024 * 1024
 const SPRITE_MAX_SIDE_PX = 512
+const UPLOAD_ERROR_DISPLAY_MS = 4000
 
 function prepareSpriteDataUrl(dataUrl: string, maxSide: number): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -68,6 +69,13 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
   spritesRef.current = sprites
   const { sprites_MIN: minN, sprites_MAX: maxN } = particleConfig
   const atCapacity = sprites.length >= maxN
+  const uploadDisabled = atCapacity || !isSignedIn
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const showUploadError = useCallback((message: string) => {
+    setUploadError(message)
+    setTimeout(() => setUploadError(null), UPLOAD_ERROR_DISPLAY_MS)
+  }, [])
 
   const setSprites = useCallback(
     (next: string[]) => {
@@ -104,8 +112,8 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
       if (!files?.length) return
       const file = files[0]
       if (!file || !file.type.startsWith('image/')) return
-      if (file.size > MAX_DATA_URL_BYTES) {
-        window.alert(`Image is too large (max ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB per file).`)
+      if (!isSignedIn) {
+        showUploadError('Sign in to upload a custom particle.')
         e.target.value = ''
         return
       }
@@ -113,8 +121,8 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
         e.target.value = ''
         return
       }
-      if (!isSignedIn) {
-        window.alert('Sign in to upload a custom particle.')
+      if (file.size > MAX_DATA_URL_BYTES) {
+        showUploadError(`Image is too large (max ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB per file).`)
         e.target.value = ''
         return
       }
@@ -128,14 +136,14 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
             const processed = await prepareSpriteDataUrl(raw, SPRITE_MAX_SIDE_PX)
             const blob = await dataUrlToBlob(processed)
             if (blob.size > MAX_DATA_URL_BYTES) {
-              window.alert(
+              showUploadError(
                 `After scaling, the image is still over ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB. Try a smaller or simpler image.`,
               )
               return
             }
             const token = await getToken()
             if (!token) {
-              window.alert('Sign in to upload a custom particle.')
+              showUploadError('Sign in to upload a custom particle.')
               return
             }
             const { data } = await axios.post<{ url: string }>('/api/uploadParticle', blob, {
@@ -143,14 +151,14 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
             })
             setSprites([...spritesRef.current, data.url])
           } catch {
-            window.alert('Could not upload this image.')
+            showUploadError('Could not upload this image.')
           }
         })()
       }
       reader.readAsDataURL(file)
       e.target.value = ''
     },
-    [sprites, maxN, setSprites, isSignedIn, getToken],
+    [sprites, maxN, setSprites, isSignedIn, getToken, showUploadError],
   )
 
   return (
@@ -208,16 +216,22 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
         </div>
         <div className='particle-sprite-hud__upload'>
           <label
-            className={`particle-sprite-hud__upload-label${atCapacity ? ' particle-sprite-hud__upload-label--disabled' : ''}`}
+            className={`particle-sprite-hud__upload-label${uploadDisabled ? ' particle-sprite-hud__upload-label--disabled' : ''}`}
+            title={!isSignedIn ? 'Sign in to upload a custom particle' : atCapacity ? `Max ${maxN} particles reached` : undefined}
           >
             + Add image
             <input
               type='file'
               accept='image/*'
-              disabled={atCapacity}
+              disabled={uploadDisabled}
               onChange={onFiles}
             />
           </label>
+          {uploadError ? (
+            <div className='particle-sprite-hud__upload-error' role='alert'>
+              {uploadError}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useRef } from 'react'
+import axios from 'axios'
+import { useAuth } from '@clerk/clerk-react'
 import './ParticleSpriteHud.css'
 
 import { connectConfig } from '../config/context/ConfigProvider'
@@ -6,6 +8,8 @@ import { AppConfig } from '../../config/configDefaults'
 import { BUILTIN_PARTICLE_SPRITES, particleConfig } from '../../config/particle.config'
 import { presetSpriteSrc } from '../../utils/presetSpriteSrc'
 
+// Mirrors the server's MAX_UPLOAD_BYTES / MAX_DECODED_DIMENSION_PX in uploadParticleHandler.ts —
+// these client-side checks only save a round trip, the server enforces its own limits independently.
 const MAX_DATA_URL_BYTES = 2 * 1024 * 1024
 const SPRITE_MAX_SIDE_PX = 512
 
@@ -41,10 +45,9 @@ function prepareSpriteDataUrl(dataUrl: string, maxSide: number): Promise<string>
   })
 }
 
-async function dataUrlByteSize(dataUrl: string): Promise<number> {
+async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
   const res = await fetch(dataUrl)
-  const blob = await res.blob()
-  return blob.size
+  return res.blob()
 }
 
 const spriteLabel = (src: string): string => {
@@ -59,6 +62,7 @@ type ParticleSpriteHudProps = {
 }
 
 const ParticleSpriteHudInner = ({ config, updateParticleSprites }: ParticleSpriteHudProps): React.ReactElement => {
+  const { isSignedIn, getToken } = useAuth()
   const sprites = config.particle.sprites.value
   const spritesRef = useRef(sprites)
   spritesRef.current = sprites
@@ -109,6 +113,12 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites }: ParticleSprit
         e.target.value = ''
         return
       }
+      if (!isSignedIn) {
+        window.alert('Sign in to upload a custom particle.')
+        e.target.value = ''
+        return
+      }
+
       const reader = new FileReader()
       reader.onload = () => {
         const raw = typeof reader.result === 'string' ? reader.result : ''
@@ -116,23 +126,31 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites }: ParticleSprit
         void (async () => {
           try {
             const processed = await prepareSpriteDataUrl(raw, SPRITE_MAX_SIDE_PX)
-            const bytes = await dataUrlByteSize(processed)
-            if (bytes > MAX_DATA_URL_BYTES) {
+            const blob = await dataUrlToBlob(processed)
+            if (blob.size > MAX_DATA_URL_BYTES) {
               window.alert(
                 `After scaling, the image is still over ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB. Try a smaller or simpler image.`,
               )
               return
             }
-            setSprites([...spritesRef.current, processed])
+            const token = await getToken()
+            if (!token) {
+              window.alert('Sign in to upload a custom particle.')
+              return
+            }
+            const { data } = await axios.post<{ url: string }>('/api/uploadParticle', blob, {
+              headers: { Authorization: `Bearer ${token}`, 'Content-Type': blob.type || 'image/png' },
+            })
+            setSprites([...spritesRef.current, data.url])
           } catch {
-            window.alert('Could not process this image.')
+            window.alert('Could not upload this image.')
           }
         })()
       }
       reader.readAsDataURL(file)
       e.target.value = ''
     },
-    [sprites, maxN, setSprites],
+    [sprites, maxN, setSprites, isSignedIn, getToken],
   )
 
   return (

--- a/src/utils/presetSpriteSrc.ts
+++ b/src/utils/presetSpriteSrc.ts
@@ -1,11 +1,16 @@
-/** Public path like `sprites/foo.png`, or inlined `data:image/...` / blob / absolute URLs from saved presets */
+/**
+ * Resolves a stored `sprite` value to something an <img>/TextureLoader can load directly.
+ * Priority: an R2 URL (absolute `https://<R2_PUBLIC_URL>/...`, stored verbatim on preset save —
+ * no key-to-URL table needed) → an existing `/public` path from before the R2 migration →
+ * any other already-absolute `data:`/`blob:`/`http(s):` reference, passed through unchanged.
+ */
 export function presetSpriteSrc(sprite: string): string {
   if (!sprite) return '/fractaleye.png'
   if (
-    sprite.startsWith('data:') ||
-    sprite.startsWith('blob:') ||
     sprite.startsWith('http://') ||
-    sprite.startsWith('https://')
+    sprite.startsWith('https://') ||
+    sprite.startsWith('data:') ||
+    sprite.startsWith('blob:')
   ) {
     return sprite
   }

--- a/src/utils/spriteCache.test.ts
+++ b/src/utils/spriteCache.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { warmSpriteCache, getResolvedSpriteUrl } from './spriteCache'
+
+type FakeCache = {
+  store: Map<string, Response>
+  match: (url: string) => Promise<Response | undefined>
+  put: (url: string, res: Response) => Promise<void>
+}
+
+const makeFakeCache = (): FakeCache => {
+  const store = new Map<string, Response>()
+  return {
+    store,
+    match: vi.fn(async (url: string) => store.get(url)),
+    put: vi.fn(async (url: string, res: Response) => {
+      store.set(url, res)
+    }),
+  }
+}
+
+describe('spriteCache', () => {
+  const originalFetch = global.fetch
+  const originalCaches = (globalThis as { caches?: unknown }).caches
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    ;(globalThis as { caches?: unknown }).caches = originalCaches
+    vi.restoreAllMocks()
+  })
+
+  it('passes local (data:/blob:/relative) sprite references through unchanged, without touching the network', async () => {
+    const fetchSpy = vi.fn()
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    await warmSpriteCache(['data:image/png;base64,AAAA', 'galaxySprite.png'])
+
+    expect(getResolvedSpriteUrl('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA')
+    expect(getResolvedSpriteUrl('galaxySprite.png')).toBe('galaxySprite.png')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the original URL when Cache Storage is unavailable', async () => {
+    ;(globalThis as { caches?: unknown }).caches = undefined
+    const url = 'https://particles.example.com/unavailable-caches.png'
+
+    await warmSpriteCache([url])
+
+    expect(getResolvedSpriteUrl(url)).toBe(url)
+  })
+
+  it('renders a previously-cached sprite with zero network access (no-network test)', async () => {
+    const fakeCache = makeFakeCache()
+    const url = 'https://particles.example.com/warm-from-earlier-session.png'
+    // Simulate a response cached during an earlier, online session.
+    fakeCache.store.set(url, new Response(new Blob(['fake-image-bytes'])))
+    ;(globalThis as { caches?: unknown }).caches = { open: vi.fn(async () => fakeCache) }
+
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('network unavailable')))
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    await warmSpriteCache([url])
+
+    const resolved = getResolvedSpriteUrl(url)
+    expect(resolved).not.toBe(url)
+    expect(resolved.startsWith('blob:')).toBe(true)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fetches and caches a not-yet-seen sprite when the network is available', async () => {
+    const fakeCache = makeFakeCache()
+    const url = 'https://particles.example.com/first-time.png'
+    ;(globalThis as { caches?: unknown }).caches = { open: vi.fn(async () => fakeCache) }
+
+    const fetchSpy = vi.fn(async () => new Response(new Blob(['fresh-image-bytes']), { status: 200 }))
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    await warmSpriteCache([url])
+
+    expect(fetchSpy).toHaveBeenCalledWith(url)
+    expect(fakeCache.store.has(url)).toBe(true)
+    expect(getResolvedSpriteUrl(url).startsWith('blob:')).toBe(true)
+  })
+
+  it('leaves an unresolvable sprite falling back to its original URL when offline and never cached', async () => {
+    const fakeCache = makeFakeCache()
+    const url = 'https://particles.example.com/never-seen-and-offline.png'
+    ;(globalThis as { caches?: unknown }).caches = { open: vi.fn(async () => fakeCache) }
+    global.fetch = vi.fn(() => Promise.reject(new Error('offline'))) as unknown as typeof fetch
+
+    await warmSpriteCache([url])
+
+    expect(getResolvedSpriteUrl(url)).toBe(url)
+  })
+})

--- a/src/utils/spriteCache.test.ts
+++ b/src/utils/spriteCache.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { warmSpriteCache, getResolvedSpriteUrl } from './spriteCache'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { warmSpriteCache as WarmSpriteCache, getResolvedSpriteUrl as GetResolvedSpriteUrl } from './spriteCache'
 
 type FakeCache = {
   store: Map<string, Response>
   match: (url: string) => Promise<Response | undefined>
   put: (url: string, res: Response) => Promise<void>
+  delete: (url: string) => Promise<boolean>
 }
 
 const makeFakeCache = (): FakeCache => {
@@ -15,12 +16,24 @@ const makeFakeCache = (): FakeCache => {
     put: vi.fn(async (url: string, res: Response) => {
       store.set(url, res)
     }),
+    delete: vi.fn(async (url: string) => store.delete(url)),
   }
 }
 
 describe('spriteCache', () => {
   const originalFetch = global.fetch
   const originalCaches = (globalThis as { caches?: unknown }).caches
+  let warmSpriteCache: typeof WarmSpriteCache
+  let getResolvedSpriteUrl: typeof GetResolvedSpriteUrl
+
+  // resolvedUrls is a private module-level singleton -- reset the module between tests so
+  // eviction in one test can't affect entries resolved by another.
+  beforeEach(async () => {
+    vi.resetModules()
+    const mod = await import('./spriteCache')
+    warmSpriteCache = mod.warmSpriteCache
+    getResolvedSpriteUrl = mod.getResolvedSpriteUrl
+  })
 
   afterEach(() => {
     global.fetch = originalFetch
@@ -90,5 +103,25 @@ describe('spriteCache', () => {
     await warmSpriteCache([url])
 
     expect(getResolvedSpriteUrl(url)).toBe(url)
+  })
+
+  it('evicts entries no longer in the active sprite list, revoking their object URL and removing them from Cache Storage', async () => {
+    const fakeCache = makeFakeCache()
+    const staleUrl = 'https://particles.example.com/stale.png'
+    const activeUrl = 'https://particles.example.com/active.png'
+    ;(globalThis as { caches?: unknown }).caches = { open: vi.fn(async () => fakeCache) }
+    global.fetch = vi.fn(async () => new Response(new Blob(['bytes']), { status: 200 })) as unknown as typeof fetch
+
+    await warmSpriteCache([staleUrl, activeUrl])
+    expect(getResolvedSpriteUrl(staleUrl).startsWith('blob:')).toBe(true)
+    expect(fakeCache.store.has(staleUrl)).toBe(true)
+
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL')
+    await warmSpriteCache([activeUrl])
+
+    expect(getResolvedSpriteUrl(staleUrl)).toBe(staleUrl)
+    expect(fakeCache.store.has(staleUrl)).toBe(false)
+    expect(revokeSpy).toHaveBeenCalledTimes(1)
+    expect(getResolvedSpriteUrl(activeUrl).startsWith('blob:')).toBe(true)
   })
 })

--- a/src/utils/spriteCache.ts
+++ b/src/utils/spriteCache.ts
@@ -1,0 +1,43 @@
+// Keeps R2-hosted particle sprites available with zero network access (live shows may have
+// none). Uses the browser's persistent Cache Storage API directly — no service worker needed,
+// pages can read/write named caches on their own. Resolution is synchronous at the point of use
+// (`getResolvedSpriteUrl`) because THREE.TextureLoader is called from a synchronous code path;
+// `warmSpriteCache` runs ahead of time (on boot, and whenever the active sprite list changes) to
+// populate the in-memory map that lookup reads from.
+const CACHE_NAME = 'fractaleyez-particle-sprites-v1'
+
+const resolvedUrls = new Map<string, string>()
+
+const isRemoteUrl = (url: string): boolean => url.startsWith('http://') || url.startsWith('https://')
+
+const cachesAvailable = (): boolean => typeof caches !== 'undefined'
+
+async function resolveOne(url: string): Promise<void> {
+  if (!isRemoteUrl(url) || resolvedUrls.has(url)) return
+  if (!cachesAvailable()) return
+
+  try {
+    const cache = await caches.open(CACHE_NAME)
+    let response = await cache.match(url)
+    if (!response) {
+      response = await fetch(url)
+      if (!response.ok) return
+      await cache.put(url, response.clone())
+    }
+    const blob = await response.blob()
+    resolvedUrls.set(url, URL.createObjectURL(blob))
+  } catch {
+    // Offline and not yet cached — nothing to do; getResolvedSpriteUrl falls back to `url`.
+  }
+}
+
+/** Best-effort: warms the resolved-URL map for the given sprite URLs. Never throws. */
+export async function warmSpriteCache(urls: string[]): Promise<void> {
+  const unique = [...new Set(urls)].filter(isRemoteUrl)
+  await Promise.all(unique.map(resolveOne))
+}
+
+/** Synchronous lookup for use in the (sync) texture-loading path. Falls back to the original URL. */
+export function getResolvedSpriteUrl(url: string): string {
+  return resolvedUrls.get(url) ?? url
+}

--- a/src/utils/spriteCache.ts
+++ b/src/utils/spriteCache.ts
@@ -31,10 +31,30 @@ async function resolveOne(url: string): Promise<void> {
   }
 }
 
-/** Best-effort: warms the resolved-URL map for the given sprite URLs. Never throws. */
+/**
+ * Drops resolved entries no longer referenced by the active sprite list: revokes their blob:
+ * URLs and removes them from Cache Storage, so switching sprite sets over a long-running session
+ * (a live show) doesn't leak object URLs or grow the cache without bound.
+ */
+async function evictStale(activeUrls: string[]): Promise<void> {
+  const active = new Set(activeUrls)
+  const stale = [...resolvedUrls.keys()].filter((url) => !active.has(url))
+  if (stale.length === 0) return
+
+  const cache = cachesAvailable() ? await caches.open(CACHE_NAME).catch(() => null) : null
+  for (const url of stale) {
+    const blobUrl = resolvedUrls.get(url)
+    if (blobUrl) URL.revokeObjectURL(blobUrl)
+    resolvedUrls.delete(url)
+    await cache?.delete(url).catch(() => false)
+  }
+}
+
+/** Best-effort: warms the resolved-URL map for the given sprite URLs and evicts stale entries. Never throws. */
 export async function warmSpriteCache(urls: string[]): Promise<void> {
   const unique = [...new Set(urls)].filter(isRemoteUrl)
   await Promise.all(unique.map(resolveOne))
+  await evictStale(unique)
 }
 
 /** Synchronous lookup for use in the (sync) texture-loading path. Falls back to the original URL. */

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -8,6 +8,21 @@ import { getResolvedSpriteUrl } from '../utils/spriteCache'
  * Modifications made by Cody Douglass and Conor O'Neill
  */
 const DEF_BRIGHTNESS = .5
+const FALLBACK_SPRITE_URL = '/fractaleye.png'
+
+// TextureLoader.load() fails asynchronously via its onError callback (e.g. a CORS-blocked
+// R2 request never fires onLoad) -- a try/catch around .load() can't see that. Catch it here
+// and fall back to the bundled sprite so a bad sprite URL doesn't leave particles blank.
+const loadSpriteTexture = (url: string): THREE.Texture => {
+  const texture = new THREE.TextureLoader().load(url, undefined, undefined, (error) => {
+    console.warn(`Failed to load particle sprite "${url}", falling back to default`, error)
+    new THREE.TextureLoader().load(FALLBACK_SPRITE_URL, (fallback) => {
+      texture.image = fallback.image
+      texture.needsUpdate = true
+    })
+  })
+  return texture
+}
 
 // Orbit parameters
 let a = 0, b = 0, c = 0, d = 0, e = 0
@@ -97,7 +112,7 @@ export class HopalongVisualizer {
   }
 
   init(): void {
-    let sprite = new THREE.TextureLoader().load(getResolvedSpriteUrl(this.sprites[0]!))
+    let sprite = loadSpriteTexture(getResolvedSpriteUrl(this.sprites[0]!))
     let count = 1
     let particleIndex = 0
     this.setLights()
@@ -120,7 +135,7 @@ export class HopalongVisualizer {
         const geometry = new THREE.BufferGeometry().setFromPoints(points)
 
         particleIndex = count % this.sprites.length
-        sprite = new THREE.TextureLoader().load(getResolvedSpriteUrl(this.sprites[particleIndex]!))
+        sprite = loadSpriteTexture(getResolvedSpriteUrl(this.sprites[particleIndex]!))
         const material = new THREE.PointsMaterial({
           size: this.particleSize,
           map: sprite,

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
+import { getResolvedSpriteUrl } from '../utils/spriteCache'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
@@ -96,7 +97,7 @@ export class HopalongVisualizer {
   }
 
   init(): void {
-    let sprite = new THREE.TextureLoader().load(this.sprites[0]!)
+    let sprite = new THREE.TextureLoader().load(getResolvedSpriteUrl(this.sprites[0]!))
     let count = 1
     let particleIndex = 0
     this.setLights()
@@ -119,7 +120,7 @@ export class HopalongVisualizer {
         const geometry = new THREE.BufferGeometry().setFromPoints(points)
 
         particleIndex = count % this.sprites.length
-        sprite = new THREE.TextureLoader().load(this.sprites[particleIndex]!)
+        sprite = new THREE.TextureLoader().load(getResolvedSpriteUrl(this.sprites[particleIndex]!))
         const material = new THREE.PointsMaterial({
           size: this.particleSize,
           map: sprite,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'server/**/*.test.ts', 'api/**/*.test.ts'],
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,225 @@
 # yarn lockfile v1
 
 
+"@aws-sdk/checksums@^3.1000.24":
+  version "3.1000.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/checksums/-/checksums-3.1000.24.tgz#7ec761472d0ad95d2a5d5d5ba09ccb3d5944bf82"
+  integrity sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-s3@^3.1101.0":
+  version "3.1101.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1101.0.tgz#24391f5d133145f16cfcf9495a9d2ee9308dea70"
+  integrity sha512-16EFb1aTEBgPcfUAWAjjlB57IZCyn7B3rlfT+xqE7M6WoH8AMMU3vFZO0UOitwh/xvvzVx73YED1/n0PU4qBMw==
+  dependencies:
+    "@aws-sdk/checksums" "^3.1000.24"
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/credential-provider-node" "^3.972.76"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.70"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.43"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.977.4":
+  version "3.977.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.977.4.tgz#5f79176ef6211c2cbb0ede941670aaa8783a4ead"
+  integrity sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==
+  dependencies:
+    "@aws-sdk/types" "^3.974.2"
+    "@aws-sdk/xml-builder" "^3.972.37"
+    "@aws/lambda-invoke-store" "^0.3.0"
+    "@smithy/core" "^3.31.1"
+    "@smithy/signature-v4" "^5.6.12"
+    "@smithy/types" "^4.16.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.65":
+  version "3.972.65"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz#d6ae13431bd2519c81a725ead809f7e0b2f8ac1a"
+  integrity sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.67":
+  version "3.972.67"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz#d15267aab521cdac9c0ae5ee6e1ed994f6559630"
+  integrity sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.973.10":
+  version "3.973.10"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz#1c15a241feb4295a05349ea37c04ab1538d6dd18"
+  integrity sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/credential-provider-env" "^3.972.65"
+    "@aws-sdk/credential-provider-http" "^3.972.67"
+    "@aws-sdk/credential-provider-login" "^3.972.72"
+    "@aws-sdk/credential-provider-process" "^3.972.65"
+    "@aws-sdk/credential-provider-sso" "^3.973.9"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.71"
+    "@aws-sdk/nested-clients" "^3.997.39"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/credential-provider-imds" "^4.4.16"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.72":
+  version "3.972.72"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz#1d7368c87b7e39ef13bfe595a876f066d7223b39"
+  integrity sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/nested-clients" "^3.997.39"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.76":
+  version "3.972.76"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz#5c9e9c563be9d23ede6901fd59ebbef3dd2f8b46"
+  integrity sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.65"
+    "@aws-sdk/credential-provider-http" "^3.972.67"
+    "@aws-sdk/credential-provider-ini" "^3.973.10"
+    "@aws-sdk/credential-provider-process" "^3.972.65"
+    "@aws-sdk/credential-provider-sso" "^3.973.9"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.71"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/credential-provider-imds" "^4.4.16"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.65":
+  version "3.972.65"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz#0cc0141ab91cfab794ada025ad1de7ec6e72966a"
+  integrity sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.973.9":
+  version "3.973.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz#5b7aa19cb9adfe98eee12f4de8f97f90853f30d7"
+  integrity sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/nested-clients" "^3.997.39"
+    "@aws-sdk/token-providers" "3.1100.0"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.71":
+  version "3.972.71"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz#4661ea124718cdb6b600168f54db65592b3dd52b"
+  integrity sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/nested-clients" "^3.997.39"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@^3.972.70":
+  version "3.972.70"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.70.tgz#1819db9d4012aa8163329641ef7acfada9bca5d5"
+  integrity sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.43"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.39":
+  version "3.997.39"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz#778e7b3f47cad80632865573f45f34ab983a3db4"
+  integrity sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.43"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/fetch-http-handler" "^5.6.13"
+    "@smithy/node-http-handler" "^4.9.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.43":
+  version "3.996.43"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz#f23113e6481741a110bb233a43d48aa40556d62b"
+  integrity sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==
+  dependencies:
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/signature-v4" "^5.6.12"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1100.0":
+  version "3.1100.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz#99bb39a1b0ee1bddefe6e90dc8435081287409db"
+  integrity sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.4"
+    "@aws-sdk/nested-clients" "^3.997.39"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.974.2":
+  version "3.974.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.974.2.tgz#05e7ccac417735e0786d430d2d5cc139047a08da"
+  integrity sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.37":
+  version "3.972.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz#669363721702d46a500c6ea485a44591e511f280"
+  integrity sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz#708802d987f8e17bdf4af4de1031660ce1cdd65f"
+  integrity sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.29.0", "@babel/code-frame@^7.29.7", "@babel/code-frame@^7.8.3":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
@@ -1928,6 +2147,57 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
+"@smithy/core@^3.31.1":
+  version "3.31.1"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.31.1.tgz#a57090db8997917d2f99eeb39db50b6283e60d3c"
+  integrity sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.4.16":
+  version "4.4.16"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz#5197900c258a7c0b6fd2b9dbc11d5410f296d7c5"
+  integrity sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==
+  dependencies:
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.6.13":
+  version "5.6.13"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz#688830a2d128aa95db5233d4ab827222a0bf4baa"
+  integrity sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==
+  dependencies:
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.9.13":
+  version "4.9.13"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz#6c0811df72deb4890d07bf81a9a8bcdf782ba824"
+  integrity sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==
+  dependencies:
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.6.12":
+  version "5.6.12"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.6.12.tgz#ee7a37e299de30e4d5c299b25485141b5b5d31c9"
+  integrity sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==
+  dependencies:
+    "@smithy/core" "^3.31.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.16.1.tgz#19e199c234829a51c085caf63f0bb17bb80187e4"
+  integrity sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==
+  dependencies:
+    tslib "^2.6.2"
+
 "@stablelib/base64@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
@@ -3071,6 +3341,11 @@ bootstrap@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -4677,6 +4952,11 @@ ignore@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+
+image-size@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-2.0.2.tgz#84a7b43704db5736f364bf0d1b029821299b4bdc"
+  integrity sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==
 
 immer@^9.0.7:
   version "9.0.21"
@@ -7054,7 +7334,7 @@ ts-toolbelt@^6.15.5:
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
   integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
-tslib@2.8.1, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.1:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary
- Particles now live in Cloudflare R2 (public bucket, immutable Cache-Control) instead of `public/`; existing preset references keep rendering unchanged via `presetSpriteSrc.ts`'s fallback chain (task #1, stack `user-platform`, 1/7).
- New authenticated `/api/uploadParticle` endpoint replaces embedding base64 `data:` URLs in preset config with an R2-hosted URL; server-side validation (auth, format allowlist, byte size, decoded pixel dimensions, user-scoped key, no overwrite) is the real boundary — the existing client-side checks in `ParticleSpriteHud.tsx` are unchanged and still just save a round trip.
- `scripts/migrate-particles-to-r2.js` uploads the built-in particle PNGs (found by walking `src/config/presets.ts` + `BUILTIN_PARTICLE_SPRITES`, filtered to what's actually in `public/`) to R2 under `builtins/`; idempotent, safe to re-run.
- Offline/live-show handling: chose the task's default recommendation (public bucket, sidesteps signed-URL expiry) plus a small client-side cache (`src/utils/spriteCache.ts`) built on the browser's Cache Storage API. It warms in the background on boot and whenever the active sprite list changes, and the visualizer's texture-loading path resolves through it synchronously — a sprite fetched once keeps rendering with zero network access. Verified with an automated no-network test (see Test plan) rather than just documented.

### Backward compatibility
Kept, not migrated: existing preset docs in Mongo still store bare filenames / old `/public` paths, and `presetSpriteSrc.ts` still resolves those exactly as before (the PNGs stay in `public/` too). New uploads and the migrated built-ins get absolute R2 URLs, which the same resolver already passes through as absolute URLs. No DB migration needed.

### NEEDS HUMAN
Create the Cloudflare R2 bucket (public) + API token, then set `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_PUBLIC_URL` in Vercel and local `.env`. After that, run `yarn migrate-particles-to-r2` once to seed the built-ins.

### Note (unrelated to this change)
`yarn lint` currently fails to even load on `master` (`@typescript-eslint` 8.57 requires eslint ^8/^9/^10, but the repo has eslint 6.8 — `eslint/use-at-your-own-risk` doesn't exist in 6.x). Confirmed pre-existing by stashing this branch's changes and re-running on `master`. Not touched here since it's an unrelated toolchain issue; relied on `yarn typecheck` + `yarn test` instead.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test` (new vitest config + suite) — 13 tests passing, covering `uploadParticleHandler` validation (auth, format allowlist, size limit, dimension limit, overwrite rejection, key scoping) and `spriteCache` including the explicit no-network scenario (pre-populated cache + rejecting `fetch` mock → resolves without ever calling `fetch`)
- [ ] Manual: create the R2 bucket per NEEDS HUMAN above, run `yarn migrate-particles-to-r2`, confirm bundled presets still render and a fresh upload round-trips through `/api/uploadParticle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated custom particle image uploads with file type, size, and dimension validation.
  * Uploaded particle images are stored remotely and served through public URLs.
  * Added sprite caching and cache warming to improve loading speed and support offline fallback.
  * Upload controls now reflect authentication and capacity limits.

* **Bug Fixes**
  * Improved handling and messaging for invalid, unavailable, oversized, or failed uploads.
  * Added a fallback sprite when custom images cannot be loaded.

* **Tests**
  * Added coverage for uploads, storage behavior, and sprite caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external dependency (R2 credentials required in all deploy environments) and authenticated upload path handling user content; mitigated by server-side validation, tests, and backward-compatible sprite resolution.
> 
> **Overview**
> **Particle sprites move from inline `data:` URLs and `public/` files to Cloudflare R2**, with a new `StorageService` (S3-compatible client), required `R2_*` env vars, and an idempotent `yarn migrate-particles-to-r2` script for built-in PNGs under `builtins/`.
> 
> **Authenticated `POST /api/uploadParticle`** validates Clerk auth, image format/size/dimensions, writes user-scoped keys (`particles/{userId}/{uuid}.{ext}`), and returns a public URL. Dev Express and Vercel (`api/uploadParticle.ts` with streaming body size cap) both wire the shared handler.
> 
> **The particle HUD** now uploads processed blobs to that API (sign-in required) instead of stuffing base64 into config; **`updateParticleSprites` / preset load** await **`spriteCache`** warming so the visualizer can resolve R2 URLs synchronously via blob URLs and Cache Storage (offline-friendly). **`hopalong-visualizer`** loads textures through `getResolvedSpriteUrl` with a default-sprite fallback on load failure.
> 
> **Vitest** is added (`yarn test`) with coverage for the upload handler and sprite cache (including no-network behavior). Existing preset sprite references still work via `presetSpriteSrc` (local paths unchanged; new uploads store absolute R2 URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c057f64e3c7e0909a00f086c3d2cac3a054dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->