### PR TITLE
fix(config): stop useAuth crash in popped-out config window

### DIFF
--- a/src/components/config/ConfigWindow.tsx
+++ b/src/components/config/ConfigWindow.tsx
@@ -26,6 +26,7 @@ const ExternalWindowBridge = ({
   savePreset,
   isSignedIn,
   currentUserId,
+  getToken,
   presets,
   packs,
 }: ExternalWindowBridgeProps): React.ReactElement => {
@@ -43,6 +44,7 @@ const ExternalWindowBridge = ({
         savePreset,
         isSignedIn,
         currentUserId,
+        getToken,
         presets,
         packs,
       }}
@@ -114,6 +116,7 @@ const ConfigWindowInner = ({
   savePreset,
   isSignedIn,
   currentUserId,
+  getToken,
   presets,
   packs,
   onClose,
@@ -158,6 +161,7 @@ const ConfigWindowInner = ({
         savePreset={savePreset}
         isSignedIn={isSignedIn}
         currentUserId={currentUserId}
+        getToken={getToken}
         presets={presets}
         packs={packs}
       />
@@ -172,6 +176,7 @@ const ConfigWindowInner = ({
     savePreset,
     isSignedIn,
     currentUserId,
+    getToken,
     presets,
   ])
 

--- a/src/components/config/context/ConfigProvider.tsx
+++ b/src/components/config/context/ConfigProvider.tsx
@@ -125,6 +125,7 @@ export type ConfigContextValue = {
   savePreset: (name: string, pack: string, force?: boolean) => Promise<void>
   isSignedIn: boolean
   currentUserId: string | null
+  getToken: () => Promise<string | null>
   presets: PresetMeta[]
   packs: PackMeta[]
 }
@@ -369,7 +370,7 @@ export const ConfigProvider = ({ children }: { children: React.ReactNode }): Rea
   }, [config, getToken])
 
   return (
-    <ConfigContext.Provider value={{ config, updateConfigItem, updateVideoClips, updateParticleSprites, retrieveConfigPreset, revertConfig, resetConfig, savePreset, isSignedIn: isSignedIn ?? false, currentUserId: user?.id ?? null, presets: presetList, packs: packList }}>
+    <ConfigContext.Provider value={{ config, updateConfigItem, updateVideoClips, updateParticleSprites, retrieveConfigPreset, revertConfig, resetConfig, savePreset, isSignedIn: isSignedIn ?? false, currentUserId: user?.id ?? null, getToken, presets: presetList, packs: packList }}>
       {children}
     </ConfigContext.Provider>
   )

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef } from 'react'
 import axios from 'axios'
-import { useAuth } from '@clerk/clerk-react'
 import './ParticleSpriteHud.css'
 
 import { connectConfig } from '../config/context/ConfigProvider'
@@ -59,10 +58,11 @@ const spriteLabel = (src: string): string => {
 type ParticleSpriteHudProps = {
   config: AppConfig
   updateParticleSprites: (sprites: string[]) => void
+  isSignedIn: boolean
+  getToken: () => Promise<string | null>
 }
 
-const ParticleSpriteHudInner = ({ config, updateParticleSprites }: ParticleSpriteHudProps): React.ReactElement => {
-  const { isSignedIn, getToken } = useAuth()
+const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, getToken }: ParticleSpriteHudProps): React.ReactElement => {
   const sprites = config.particle.sprites.value
   const spritesRef = useRef(sprites)
   spritesRef.current = sprites


### PR DESCRIPTION
## Summary
- `ParticleSpriteHud` called `useAuth()` directly, which throws unless there's a `ClerkProvider` ancestor
- The popout config window (`ConfigWindow.tsx`) renders into a separate React root that isn't a descendant of the main window's `ClerkProvider`, so expanding config into a new window crashed the popout with "useAuth can only be used within the `<ClerkProvider />`"
- Fix: thread `getToken` through `ConfigContext` (same pattern as the existing `isSignedIn`/`currentUserId`) instead of calling `useAuth()` inside the HUD, so the popout gets auth data from the main window's provider tree instead of trying to establish its own

## Test plan
- [x] `yarn typecheck` passes
- [ ] Manually verify: open the config popout window, upload a custom particle while signed in — should succeed without the Clerk error
- [ ] Manually verify: same flow while signed out — should show the "Sign in to upload" alert instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth plumbing change; upload behavior should match the main window, with no new server or security surface.
> 
> **Overview**
> Fixes a crash when opening the **config popout** (`ParticleSpriteHud` inside `ConfigWindow`): that UI renders in a separate React root that is not under the main window’s `ClerkProvider`, so direct `useAuth()` threw.
> 
> **`getToken`** is added to `ConfigContext` (alongside existing `isSignedIn` / `currentUserId`), supplied from `ConfigProvider` via `useAuth`, and passed through `ExternalWindowBridge` when the popout re-renders. **`ParticleSpriteHud`** drops `useAuth` and uses `isSignedIn` and `getToken` from `connectConfig` for upload gating and the `/api/uploadParticle` bearer token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fa3bd502dbf29f394440db5a600c87c4243ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->