### PR TITLE
fix(particles): disable upload when signed out, show errors inline

### DIFF
--- a/src/components/huds/ParticleSpriteHud.css
+++ b/src/components/huds/ParticleSpriteHud.css
@@ -138,7 +138,7 @@
   transition: border-color 0.15s ease, color 0.15s ease;
 }
 
-.particle-sprite-hud__upload-label:hover {
+.particle-sprite-hud__upload-label:hover:not(.particle-sprite-hud__upload-label--disabled) {
   border-color: #004400;
   color: #ccc;
 }
@@ -146,7 +146,6 @@
 .particle-sprite-hud__upload-label--disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 .particle-sprite-hud__upload input {
@@ -155,4 +154,11 @@
   height: 0;
   opacity: 0;
   pointer-events: none;
+}
+
+.particle-sprite-hud__upload-error {
+  font-size: 10px;
+  line-height: 1.3;
+  color: #e08080;
+  text-align: center;
 }

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import axios from 'axios'
 import './ParticleSpriteHud.css'
 
@@ -11,6 +11,7 @@ import { presetSpriteSrc } from '../../utils/presetSpriteSrc'
 // these client-side checks only save a round trip, the server enforces its own limits independently.
 const MAX_DATA_URL_BYTES = 2 * 1024 * 1024
 const SPRITE_MAX_SIDE_PX = 512
+const UPLOAD_ERROR_DISPLAY_MS = 4000
 
 function prepareSpriteDataUrl(dataUrl: string, maxSide: number): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -68,6 +69,13 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
   spritesRef.current = sprites
   const { sprites_MIN: minN, sprites_MAX: maxN } = particleConfig
   const atCapacity = sprites.length >= maxN
+  const uploadDisabled = atCapacity || !isSignedIn
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const showUploadError = useCallback((message: string) => {
+    setUploadError(message)
+    setTimeout(() => setUploadError(null), UPLOAD_ERROR_DISPLAY_MS)
+  }, [])
 
   const setSprites = useCallback(
     (next: string[]) => {
@@ -104,8 +112,8 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
       if (!files?.length) return
       const file = files[0]
       if (!file || !file.type.startsWith('image/')) return
-      if (file.size > MAX_DATA_URL_BYTES) {
-        window.alert(`Image is too large (max ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB per file).`)
+      if (!isSignedIn) {
+        showUploadError('Sign in to upload a custom particle.')
         e.target.value = ''
         return
       }
@@ -113,8 +121,8 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
         e.target.value = ''
         return
       }
-      if (!isSignedIn) {
-        window.alert('Sign in to upload a custom particle.')
+      if (file.size > MAX_DATA_URL_BYTES) {
+        showUploadError(`Image is too large (max ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB per file).`)
         e.target.value = ''
         return
       }
@@ -128,14 +136,14 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
             const processed = await prepareSpriteDataUrl(raw, SPRITE_MAX_SIDE_PX)
             const blob = await dataUrlToBlob(processed)
             if (blob.size > MAX_DATA_URL_BYTES) {
-              window.alert(
+              showUploadError(
                 `After scaling, the image is still over ${MAX_DATA_URL_BYTES / (1024 * 1024)} MB. Try a smaller or simpler image.`,
               )
               return
             }
             const token = await getToken()
             if (!token) {
-              window.alert('Sign in to upload a custom particle.')
+              showUploadError('Sign in to upload a custom particle.')
               return
             }
             const { data } = await axios.post<{ url: string }>('/api/uploadParticle', blob, {
@@ -143,14 +151,14 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
             })
             setSprites([...spritesRef.current, data.url])
           } catch {
-            window.alert('Could not upload this image.')
+            showUploadError('Could not upload this image.')
           }
         })()
       }
       reader.readAsDataURL(file)
       e.target.value = ''
     },
-    [sprites, maxN, setSprites, isSignedIn, getToken],
+    [sprites, maxN, setSprites, isSignedIn, getToken, showUploadError],
   )
 
   return (
@@ -208,16 +216,22 @@ const ParticleSpriteHudInner = ({ config, updateParticleSprites, isSignedIn, get
         </div>
         <div className='particle-sprite-hud__upload'>
           <label
-            className={`particle-sprite-hud__upload-label${atCapacity ? ' particle-sprite-hud__upload-label--disabled' : ''}`}
+            className={`particle-sprite-hud__upload-label${uploadDisabled ? ' particle-sprite-hud__upload-label--disabled' : ''}`}
+            title={!isSignedIn ? 'Sign in to upload a custom particle' : atCapacity ? `Max ${maxN} particles reached` : undefined}
           >
             + Add image
             <input
               type='file'
               accept='image/*'
-              disabled={atCapacity}
+              disabled={uploadDisabled}
               onChange={onFiles}
             />
           </label>
+          {uploadError ? (
+            <div className='particle-sprite-hud__upload-error' role='alert'>
+              {uploadError}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Signed-out users could previously select a file for upload before getting rejected via `window.alert()`. The upload control (label + file input) is now disabled whenever signed out, not just at capacity, with a `not-allowed` cursor and a title tooltip explaining why
- Fixed the CSS so the disabled cursor actually renders — the existing `--disabled` modifier set `pointer-events: none` on the label, which prevented the browser from ever painting the label's own `cursor: not-allowed` (it fell through to whatever's behind it). The file input itself already carries `disabled`, so removing `pointer-events: none` from the label doesn't reopen a way to trigger the upload
- Replaced all `window.alert()` calls in the upload flow (too large, still too large after scaling, not signed in, upload failed) with an inline error message rendered under the upload control in `ParticleSpriteHud`, auto-clearing after 4s

## Test plan
- [x] `yarn typecheck` passes
- [ ] Signed out: hover "+ Add image" — cursor shows not-allowed, no file picker opens, tooltip explains why
- [ ] Signed in, upload an oversized image — inline error appears under the control (no browser alert)
- [ ] Signed in, successful upload — new sprite appears in Active list, no error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the particle HUD upload flow; no auth, API, or server behavior changes beyond replacing alerts with inline messages.
> 
> **Overview**
> **Particle sprite upload** is tightened for signed-out users and clearer feedback when uploads fail.
> 
> The **+ Add image** control is disabled when the user is not signed in (not only at max particle count), with a tooltip explaining why. CSS no longer uses `pointer-events: none` on the disabled label so **`cursor: not-allowed`** actually shows; hover styles are skipped when disabled.
> 
> All upload validation and failure paths that used **`window.alert()`** now set a short **inline error** under the control (`role="alert"`), auto-clearing after 4 seconds—covering sign-in required, size limits, post-scale size, and upload API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6dcb9faf45fe50f45c23d32a60f48e758ba0b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->