### PR TITLE
fix(config-popout): config popout window UX fixes

### DIFF
--- a/src/components/config/ConfigCategory.tsx
+++ b/src/components/config/ConfigCategory.tsx
@@ -7,6 +7,13 @@ import { ConfigCheckbox } from './ConfigCheckbox'
 import { connectConfig } from './context/ConfigProvider'
 import { AppConfig, ConfigItem, SliderItem } from '../../config/configDefaults'
 
+// Per-field overrides for how a slider's raw numeric value is displayed; the raw value
+// itself (min/max/step/onChange) is untouched, only the text shown next to the slider.
+const SLIDER_DISPLAY_FORMATTERS: Partial<Record<string, (value: number) => string>> = {
+  scaleFactor: (value) => `${(value / 1000).toFixed(1)}x`,
+  cameraBound: (value) => (value / 100).toFixed(1),
+}
+
 type ConfigCategoryProps = {
   name: string
   config: AppConfig
@@ -62,6 +69,7 @@ const ConfigCategoryInner = React.memo(({ name, config, isOpen, toggleOpen, onCh
                 label={label}
                 key={configItem}
                 value={value as number}
+                displayValue={SLIDER_DISPLAY_FORMATTERS[configItem]?.(value as number)}
                 min={min}
                 max={max}
                 step={step}

--- a/src/components/config/ConfigSlider.tsx
+++ b/src/components/config/ConfigSlider.tsx
@@ -5,17 +5,18 @@ type ConfigSliderProps = {
   name: string
   label?: string
   value: number
+  displayValue?: string
   min: number
   max: number
   step: number
   onChange: React.ChangeEventHandler<HTMLInputElement>
 }
 
-export const ConfigSlider = React.memo(({ name, label, value, min, max, step, onChange }: ConfigSliderProps) => (
+export const ConfigSlider = React.memo(({ name, label, value, displayValue, min, max, step, onChange }: ConfigSliderProps) => (
   <div>
     <div className="slider-info">
       <h4 className="slider-name">{label || name}: </h4>
-      <h4 className="slider-value">{value}</h4>
+      <h4 className="slider-value">{displayValue ?? value}</h4>
     </div>
     <input type="range"
       className="slider-input"

--- a/src/components/config/ConfigWindow.tsx
+++ b/src/components/config/ConfigWindow.tsx
@@ -12,6 +12,23 @@ import { connectConfig, ConfigContext, ConfigContextValue } from './context/Conf
 import { CameraTouchpad } from './CameraTouchpad'
 import { FrequencyHud, PerfHud, ParticleSpriteHud } from '../huds'
 
+const DEFAULT_WINDOW_FEATURES = 'width=1200,height=860,location=no'
+
+// Positions the popout on a second screen at full available height when the Window Management
+// API is available and permitted; falls back to the default same-screen size/placement otherwise
+// (unsupported in Firefox/Safari, and requires a permission prompt in Chromium).
+const resolveWindowFeatures = async (): Promise<string> => {
+  if (!window.getScreenDetails || !window.screen.isExtended) return DEFAULT_WINDOW_FEATURES
+  try {
+    const screenDetails = await window.getScreenDetails()
+    const secondScreen = screenDetails.screens.find((s) => s !== screenDetails.currentScreen)
+    if (!secondScreen) return DEFAULT_WINDOW_FEATURES
+    return `width=1200,height=${secondScreen.availHeight},left=${secondScreen.availLeft},top=${secondScreen.availTop},location=no`
+  } catch {
+    return DEFAULT_WINDOW_FEATURES
+  }
+}
+
 type ExternalWindowBridgeProps = ConfigContextValue
 
 // Renders inside the external window's React root, bridging ConfigContext from the main window
@@ -122,27 +139,45 @@ const ConfigWindowInner = ({
   onClose,
 }: ConfigWindowProps): null => {
   const reactRootRef = useRef<Root | null>(null)
+  // Root creation is now async (waits on second-screen resolution) — this flips once the root
+  // exists so the render effect below re-fires even if config/presets/etc haven't changed since.
+  const [externalRootReady, setExternalRootReady] = useState(false)
 
   // Open the external window once on mount
   useEffect(() => {
-    const externalWindow = window.open('', '', 'width=1200,height=860,location=no')
-    if (!externalWindow) return
+    let cancelled = false
+    let externalWindow: Window | null = null
 
-    const container = externalWindow.document.createElement('div')
-    container.className = 'config-window-root'
-    externalWindow.document.title = 'Configuration'
-    externalWindow.document.body.appendChild(container)
-    externalWindow.addEventListener('beforeunload', onClose)
-    copyStyles(document, externalWindow.document)
+    const closeExternalWindow = (): void => externalWindow?.close()
 
-    const reactRoot = createRoot(container)
-    reactRootRef.current = reactRoot
+    const setup = async (): Promise<void> => {
+      const features = await resolveWindowFeatures()
+      if (cancelled) return
+
+      externalWindow = window.open('', '', features)
+      if (!externalWindow) return
+
+      const container = externalWindow.document.createElement('div')
+      container.className = 'config-window-root'
+      externalWindow.document.title = 'Configuration'
+      externalWindow.document.body.appendChild(container)
+      externalWindow.addEventListener('beforeunload', onClose)
+      window.addEventListener('beforeunload', closeExternalWindow)
+      copyStyles(document, externalWindow.document)
+
+      reactRootRef.current = createRoot(container)
+      setExternalRootReady(true)
+    }
+
+    void setup()
 
     return () => {
-      externalWindow.removeEventListener('beforeunload', onClose)
-      reactRoot.unmount()
+      cancelled = true
+      window.removeEventListener('beforeunload', closeExternalWindow)
+      externalWindow?.removeEventListener('beforeunload', onClose)
+      reactRootRef.current?.unmount()
       reactRootRef.current = null
-      externalWindow.close()
+      externalWindow?.close()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -167,6 +202,7 @@ const ConfigWindowInner = ({
       />
     )
   }, [
+    externalRootReady,
     config,
     updateConfigItem,
     updateVideoClips,

--- a/src/components/config/ConfigWindow.tsx
+++ b/src/components/config/ConfigWindow.tsx
@@ -13,6 +13,7 @@ import { CameraTouchpad } from './CameraTouchpad'
 import { FrequencyHud, PerfHud, ParticleSpriteHud } from '../huds'
 
 const DEFAULT_WINDOW_FEATURES = 'width=1200,height=860,location=no'
+const POPOUT_WIDTH = 1200
 
 // Positions the popout on a second screen at full available height when the Window Management
 // API is available and permitted; falls back to the default same-screen size/placement otherwise
@@ -21,9 +22,17 @@ const resolveWindowFeatures = async (): Promise<string> => {
   if (!window.getScreenDetails || !window.screen.isExtended) return DEFAULT_WINDOW_FEATURES
   try {
     const screenDetails = await window.getScreenDetails()
-    const secondScreen = screenDetails.screens.find((s) => s !== screenDetails.currentScreen)
+    const { currentScreen } = screenDetails
+    const secondScreen = screenDetails.screens.find((s) => s !== currentScreen)
     if (!secondScreen) return DEFAULT_WINDOW_FEATURES
-    return `width=1200,height=${secondScreen.availHeight},left=${secondScreen.availLeft},top=${secondScreen.availTop},location=no`
+    // Dock against the seam between the two screens rather than always at the second
+    // screen's left edge: if it's to the left of the current screen, that seam is its
+    // right edge; if it's to the right, the seam is its left edge (today's behavior).
+    const secondScreenIsToTheLeft = secondScreen.availLeft < currentScreen.availLeft
+    const left = secondScreenIsToTheLeft
+      ? secondScreen.availLeft + secondScreen.availWidth - POPOUT_WIDTH
+      : secondScreen.availLeft
+    return `width=${POPOUT_WIDTH},height=${secondScreen.availHeight},left=${left},top=${secondScreen.availTop},location=no`
   } catch {
     return DEFAULT_WINDOW_FEATURES
   }

--- a/src/components/config/Slider.css
+++ b/src/components/config/Slider.css
@@ -53,9 +53,8 @@
   outline: none;
 }
 
-/* The popout's .config-window-root bumps the base font size, and its columns are
-   narrower than the sidebar accordion's — without this, labels like "Sound Threshold"
-   wrap to a 2nd line there even though they fit fine in the sidebar. */
+/* Slider labels read too small in the popout at the sidebar's default size. Labels are
+   short now (Speed, Scale, Cam Wiggle, ...) so there's room to size up further. */
 .config-window-root .slider-name {
-  font-size: 0.85rem;
+  font-size: 1.75rem;
 }

--- a/src/components/config/Slider.css
+++ b/src/components/config/Slider.css
@@ -52,3 +52,10 @@
   transition-duration: .1;
   outline: none;
 }
+
+/* The popout's .config-window-root bumps the base font size, and its columns are
+   narrower than the sidebar accordion's — without this, labels like "Sound Threshold"
+   wrap to a 2nd line there even though they fit fine in the sidebar. */
+.config-window-root .slider-name {
+  font-size: 0.85rem;
+}

--- a/src/components/presets/Presets.css
+++ b/src/components/presets/Presets.css
@@ -22,15 +22,11 @@
   max-width: 100%;
 }
 
-.pack-tabs-row .pack-tabs {
-  margin-bottom: 0;
-}
-
 .pack-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-bottom: 0.75rem;
+  gap: 1rem 0.6rem;
+  margin: 0.6rem;
 }
 
 .pack-tab {
@@ -133,7 +129,7 @@
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
-  min-height: 140px;
+  min-height: 180px;
   transition: opacity 0.15s ease;
 }
 
@@ -142,7 +138,7 @@
 }
 
 .presets-grid--expanded {
-  min-height: 130px;
+  min-height: 135px;
 }
 
 
@@ -207,7 +203,13 @@
   align-items: center;
   gap: 1rem;
   margin-top: 0.75rem;
-  padding-left: 0.5rem;
+  padding-left: 0.75rem;
+}
+
+/* Kept in the layout (not display: none) so switching to a single-page pack doesn't
+   shift the sidebar content that follows it up. */
+.presets-pagination--hidden {
+  visibility: hidden;
 }
 
 .pagination-arrow {

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -129,23 +129,21 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
             })}
           </div>
           </div>
-          {totalPages > 1 && (
-            <div className='presets-pagination'>
-              <button
-                className='pagination-arrow'
-                onClick={() => changePage(page === 0 ? totalPages - 1 : page - 1)}
-              >
-                &#8592;
-              </button>
-              <span className='pagination-label'>{page + 1} / {totalPages}</span>
-              <button
-                className='pagination-arrow'
-                onClick={() => changePage(page === totalPages - 1 ? 0 : page + 1)}
-              >
-                &#8594;
-              </button>
-            </div>
-          )}
+          <div className={`presets-pagination${totalPages > 1 ? '' : ' presets-pagination--hidden'}`}>
+            <button
+              className='pagination-arrow'
+              onClick={() => changePage(page === 0 ? totalPages - 1 : page - 1)}
+            >
+              &#8592;
+            </button>
+            <span className='pagination-label'>{page + 1} / {totalPages}</span>
+            <button
+              className='pagination-arrow'
+              onClick={() => changePage(page === totalPages - 1 ? 0 : page + 1)}
+            >
+              &#8594;
+            </button>
+          </div>
         </Col>
       </Row>
       {modalVisible && (

--- a/src/components/sidebar/Sidebar.css
+++ b/src/components/sidebar/Sidebar.css
@@ -19,7 +19,62 @@
   color: rgba(220,220,220,.9);
   border-right: 3px solid rgba(20,20,20,.9);
   opacity: .9;
-  padding: 10px 20px;
+  padding: 8px 0;
+}
+
+/* Wraps everything but the .tab button, which needs .sidebar-content to stay
+   unclipped so it can poke out past the right edge (left: 100%, see .tab below). */
+.sidebar-scroll {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  /* Always reserves the scrollbar's own space in the box's width, so content shrinks
+     to fit it instead of the scrollbar overlapping/clipping into the padded content. */
+  scrollbar-gutter: stable;
+  /* Flips the scrollbar to the left edge; content direction is flipped back below
+     so text/layout inside reads normally. */
+  direction: rtl;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(150, 150, 150, 0.15) transparent;
+}
+
+.sidebar-scroll > * {
+  direction: ltr;
+}
+
+/* Bootstrap 3's .row carries a built-in -15px margin on each side, meant to be
+   cancelled out by a .col-*'s matching padding. Nothing here passes a breakpoint
+   prop to Col, so no col-* class (and no offsetting padding) is ever applied —
+   the -15px bleed was previously invisible (no horizontal clipping existed), but
+   now overflow-x: hidden above clips it, cutting off the right edge of content. */
+.sidebar-scroll .row {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.sidebar-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb {
+  background-color: rgba(150, 150, 150, 0.35);
+  border-radius: 3px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(150, 150, 150, 0.55);
+}
+
+.sidebar-scroll::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 @media only screen and (max-width: 600px) {
@@ -261,7 +316,7 @@
   font-size: 2.75rem;
 }
 
-.sidebar-content:not(.slide-in) > .row > .sidebar-title {
+.sidebar-content:not(.slide-in) .sidebar-scroll > .row > .sidebar-title {
   display: none;
 }
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -40,7 +40,10 @@ const SidebarInner = ({ config: _config, setConfigWindow, configWindowVisible }:
 
   const toggleSidebar = useCallback(() => setSidebarVisible((prev) => !prev), [])
 
-  const handleSetConfigWindow = useCallback(() => setConfigWindow(), [setConfigWindow])
+  const handleSetConfigWindow = useCallback(() => {
+    if (!configWindowVisible) setSidebarVisible(false)
+    setConfigWindow()
+  }, [setConfigWindow, configWindowVisible])
 
   useEffect(() => {
     hideTabDelayed(5000)
@@ -96,7 +99,7 @@ const SidebarInner = ({ config: _config, setConfigWindow, configWindowVisible }:
             ⤢
           </button>
         </Row>
-        {!configWindowVisible && <ConfigAccordion canOpenMultiple={false} />}
+        <ConfigAccordion canOpenMultiple={false} />
       </Grid>
     </div>
   )

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -81,25 +81,27 @@ const SidebarInner = ({ config: _config, setConfigWindow, configWindowVisible }:
           onClick={toggleSidebar}>
           Menu
         </button>
-        <Row>
-          <div className='sidebar-title-row'>
-            <h2 className='sidebar-title'>Presets</h2>
-            <SavePreset prefill={prefill} onSaved={() => setPrefill(null)} />
-          </div>
-        </Row>
-        <Presets
-          onSelect={setPrefill}
-          onPackSelect={(pack: string) => setPrefill(prev => prev ? { ...prev, pack } : { name: '', label: '', pack, isOwn: false })}
-        />
-        <Row>
-          <h2 className='sidebar-title'>Configuration</h2>
-          <button
-            className={expandConfigClasses}
-            onClick={handleSetConfigWindow}>
-            ⤢
-          </button>
-        </Row>
-        <ConfigAccordion canOpenMultiple={false} />
+        <div className='sidebar-scroll'>
+          <Row>
+            <div className='sidebar-title-row'>
+              <h2 className='sidebar-title'>Presets</h2>
+              <SavePreset prefill={prefill} onSaved={() => setPrefill(null)} />
+            </div>
+          </Row>
+          <Presets
+            onSelect={setPrefill}
+            onPackSelect={(pack: string) => setPrefill(prev => prev ? { ...prev, pack } : { name: '', label: '', pack, isOwn: false })}
+          />
+          <Row>
+            <h2 className='sidebar-title'>Configuration</h2>
+            <button
+              className={expandConfigClasses}
+              onClick={handleSetConfigWindow}>
+              ⤢
+            </button>
+          </Row>
+          <ConfigAccordion canOpenMultiple={false} />
+        </div>
       </Grid>
     </div>
   )

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -96,7 +96,7 @@ const SidebarInner = ({ config: _config, setConfigWindow, configWindowVisible }:
             ⤢
           </button>
         </Row>
-        <ConfigAccordion canOpenMultiple={false} />
+        {!configWindowVisible && <ConfigAccordion canOpenMultiple={false} />}
       </Grid>
     </div>
   )

--- a/src/config/configDefaults.ts
+++ b/src/config/configDefaults.ts
@@ -124,7 +124,7 @@ export const configDefaults: AppConfig = {
       step: userConfig.speed_STEP_SIZE,
     },
     rotationSpeed: {
-      name: 'Rotation Speed',
+      name: 'Rotation',
       type: 'slider',
       defaultValue: userConfig.rotationSpeed_DEFAULT,
       value: userConfig.rotationSpeed_DEFAULT,
@@ -133,7 +133,7 @@ export const configDefaults: AppConfig = {
       step: userConfig.rotationSpeed_STEP_SIZE,
     },
     scaleFactor: {
-      name: 'Scale Factor',
+      name: 'Scale',
       type: 'slider',
       defaultValue: userConfig.scaleFactor_DEFAULT,
       value: userConfig.scaleFactor_DEFAULT,
@@ -142,7 +142,7 @@ export const configDefaults: AppConfig = {
       step: userConfig.scaleFactor_STEP_SIZE,
     },
     cameraBound: {
-      name: 'Camera Bound',
+      name: 'Sway',
       type: 'slider',
       defaultValue: userConfig.cameraBound_DEFAULT,
       value: userConfig.cameraBound_DEFAULT,
@@ -153,7 +153,7 @@ export const configDefaults: AppConfig = {
   },
   audio: {
     soundThreshold: {
-      name: 'Sound Threshold',
+      name: 'Threshold',
       type: 'slider',
       defaultValue: pd.threshold_DEFAULT,
       value: pd.threshold_DEFAULT,
@@ -180,8 +180,8 @@ export const configDefaults: AppConfig = {
     shockwave: { name: 'Shockwave', type: 'checkbox', defaultValue: visualizerConfig.shockwave, value: visualizerConfig.shockwave },
   },
   particle: {
-    particleSize: { name: 'Particle Size', type: 'slider', defaultValue: particleConfig.size_DEFAULT, value: particleConfig.size_DEFAULT, min: particleConfig.size_MIN, max: particleConfig.size_MAX, step: particleConfig.size_STEP_SIZE },
-    particlesPerLayer: { name: 'Particles Per Layer', type: 'slider', defaultValue: particleConfig.particles_DEFAULT, value: particleConfig.particles_DEFAULT, min: particleConfig.particles_MIN, max: particleConfig.particles_MAX, step: particleConfig.particles_STEP_SIZE },
+    particleSize: { name: 'Size', type: 'slider', defaultValue: particleConfig.size_DEFAULT, value: particleConfig.size_DEFAULT, min: particleConfig.size_MIN, max: particleConfig.size_MAX, step: particleConfig.size_STEP_SIZE },
+    particlesPerLayer: { name: 'Count', type: 'slider', defaultValue: particleConfig.particles_DEFAULT, value: particleConfig.particles_DEFAULT, min: particleConfig.particles_MIN, max: particleConfig.particles_MAX, step: particleConfig.particles_STEP_SIZE },
     layers: { name: 'Layers', type: 'slider', defaultValue: particleConfig.layers_DEFAULT, value: particleConfig.layers_DEFAULT, min: particleConfig.layers_MIN, max: particleConfig.layers_MAX, step: particleConfig.layers_STEP_SIZE },
     levels: { name: 'Levels', type: 'slider', defaultValue: particleConfig.levels_DEFAULT, value: particleConfig.levels_DEFAULT, min: particleConfig.levels_MIN, max: particleConfig.levels_MAX, step: particleConfig.levels_STEP_SIZE },
     saturation: { name: 'Saturation', type: 'slider', defaultValue: particleConfig.saturation_DEFAULT, value: particleConfig.saturation_DEFAULT, min: particleConfig.saturation_MIN, max: particleConfig.saturation_MAX, step: particleConfig.saturation_STEP_SIZE },

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,23 @@
 import type { AppConfig } from '../config/configDefaults'
 
+// Window Management API — not yet in TypeScript's lib.dom.d.ts.
+// https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API
+interface ScreenDetailed extends Screen {
+  readonly availLeft: number
+  readonly availTop: number
+  readonly left: number
+  readonly top: number
+  readonly isPrimary: boolean
+  readonly isInternal: boolean
+  readonly devicePixelRatio: number
+  readonly label: string
+}
+
+interface ScreenDetails extends EventTarget {
+  readonly screens: ScreenDetailed[]
+  readonly currentScreen: ScreenDetailed
+}
+
 declare global {
   interface Window {
     config: AppConfig
@@ -18,6 +36,11 @@ declare global {
       pingMs: number | null
       estimatedLagMs: number
     }
+    getScreenDetails?: () => Promise<ScreenDetails>
+  }
+
+  interface Screen {
+    readonly isExtended?: boolean
   }
 }
 


### PR DESCRIPTION
## Summary
- Popout auto-closes when the main/parent tab reloads or closes (new `beforeunload` listener on `window`, mirroring the existing listener on the popout itself in `ConfigWindow.tsx`).
- Sidebar's `ConfigAccordion` is hidden while the popout is open (`Sidebar.tsx` now gates the accordion render on the existing `configWindowVisible` prop).
- Setting-title labels ("Speed", "Sound Threshold") no longer wrap to a 2nd line in the popout — added a `.config-window-root .slider-name` font-size override in `Slider.css`, scoped so the sidebar's own accordion is unaffected.
- Popout opens on a 2nd screen at full `100vh` (width unchanged) when detected/available, using the Window Management API (`getScreenDetails()` / `window.screen.isExtended`). Falls back to today's same-screen sizing when unsupported (Firefox/Safari have no such API) or denied (Chromium prompts for permission).

## Implementation notes
- Ambient types for the Window Management API added to `src/types/global.d.ts` — not yet present in TypeScript's `lib.dom.d.ts`.
- Opening the popout is now async (it awaits screen resolution before `window.open`), so the root-creation effect gained a `cancelled` guard, and a new `externalRootReady` flag was added to the render effect's deps — without it, the render effect (which previously ran synchronously right after root creation in the same commit) could fire before the async root exists and never get triggered again until an unrelated prop changed.

## NEEDS HUMAN
None required. The Window Management API isn't supported in Firefox/Safari and requires a Chromium permission prompt; unsupported/denied browsers just degrade to current single-screen behavior.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (14/14)
- [ ] `yarn lint` — currently broken on `main` independent of this change (eslint 6 / `@typescript-eslint` 8 incompatibility, tracked and fixed separately in #151/task #16). Ran the changed files through the eslint 8 binary already present in `node_modules` as a sanity check instead; no new issues beyond the two pre-existing rule-definition errors that #151 resolves.
- [ ] Manual verification of the popout behavior (2nd-screen placement, accordion hiding, auto-close, label wrapping) not done in this session — no browser available; flagging for manual QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, window placement, and display formatting; async popout open adds lifecycle edge cases but degrades safely when the API is missing or denied.
> 
> **Overview**
> Improves the **config popout** and **sidebar** experience: the popout can open on a second monitor at full height via the Window Management API (with a same-screen fallback), closes when the parent tab unloads, and uses async setup with `externalRootReady` so React still mounts after screen resolution.
> 
> **Config UI:** Sliders gain an optional `displayValue` so **Scale** shows as `Nx` and **Sway** as a decimal without changing stored values; popout-only CSS enlarges slider labels. Several config labels are shortened in `configDefaults`.
> 
> **Sidebar:** Presets and configuration live in a scrollable `.sidebar-scroll` region (left-edge scrollbar, Bootstrap row margin fix). Opening the popout collapses the sidebar. Preset pack tabs, grid min-heights, and pagination use layout tweaks; pagination stays in the DOM with `visibility: hidden` on single-page packs to avoid layout jump.
> 
> **Types:** `global.d.ts` adds Window Management API typings for `getScreenDetails` / extended screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbf90493018c456def04eceb4a6276387411070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration popouts can open on a secondary display when supported, with graceful fallback on unsupported setups.
  * Improved sidebar scrolling, touch support, and content visibility.
  * Sidebar now hides automatically when opening configuration.
* **UI Improvements**
  * Added clearer formatting for scale and camera settings.
  * Increased configuration slider label sizes.
  * Updated configuration labels with shorter names.
  * Improved preset spacing, wrapping, and pagination layout.
* **Bug Fixes**
  * Prevented sidebar content and preset controls from being clipped during resizing or scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->