### PR TITLE
chore: session housekeeping 2026-08-06

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -4,14 +4,6 @@ Instructions for agent: This file is the task inventory only. Workflow rules (br
 
 ## Agent-Ready
 
-- [ ] #16 [stack: solo] Fix lint toolchain break — bump eslint for @typescript-eslint 8.x compatibility.
-  - Acceptance: `yarn lint` loads and runs successfully against `src/`.
-  - Sub-tasks: (1) Bump `eslint` from `^6.8.0` to `^8.57.0` in package.json — keeps the existing legacy `.eslintrc` format working and avoids eslint 9's flat-config migration. (2) `yarn install`, then `yarn lint`, fix any lint errors newly surfaced by stricter eslint 8 core rules. (3) Check `babel-eslint`/`eslint-scope`/`eslint-plugin-jsdoc`/`eslint-plugin-prefer-arrow` for eslint-8 peer-dep warnings post-bump; upgrade if needed.
-  - NEEDS HUMAN: none anticipated.
-- [ ] #17 [stack: solo] Config popout window UX fixes.
-  - Acceptance: (1) popout closes automatically when the main/parent tab reloads or closes; (2) sidebar's `ConfigAccordion` is hidden while the popout is open; (3) setting-title labels ("Speed", "Sound Threshold") don't wrap to a 2nd line in the popout; (4) popout opens on a 2nd screen when detected/available, sized to full `100vh`, width unchanged.
-  - Sub-tasks: (1) Add a `beforeunload` listener on the main `window` in `ConfigWindow.tsx` that closes `externalWindow` — mirrors the existing pattern at line 135 but on the parent window object instead of the popout's. (2) In `Sidebar.tsx`, conditionally hide `ConfigAccordion` (line 99) when `configWindowVisible` is true — the prop already exists, just needs to gate the accordion render too. (3) Add a font-size override for `.slider-name` in `Slider.css` (currently unset, inherits `<h4>` default), scoped to the popout context so the sidebar's own accordion layout isn't affected. (4) Use the Window Management API (`getScreenDetails()`/`window.screen.isExtended`) where available to detect a 2nd screen and position `window.open` there sized to `100vh`; fall back to current same-screen sizing if unsupported/permission denied.
-  - NEEDS HUMAN: none required — Window Management API isn't supported in Firefox/Safari and requires a permission prompt in Chromium; note in the PR that unsupported browsers degrade gracefully to current single-screen behavior.
 - [ ] #18 [stack: solo] Auto-strip background from uploaded particle sprites.
   - Acceptance: uploading a sprite with a black/gray/white background produces a stored/rendered sprite with that background removed via edge flood-fill (not a global per-pixel threshold); cutoff edges have soft alpha falloff; dark outlines/white highlights in the art interior are preserved.
   - Sub-tasks: (1) Implement edge-inward flood-fill in `ParticleSpriteHud.tsx`'s `prepareSpriteDataUrl()`, alongside the existing resize step, before upload (client-side canvas pixel access is already in play there). (2) Apply distance-based alpha falloff near the flood-fill boundary instead of a hard cutoff. (3) Only flood-fill from near-neutral (black/gray/white) edge pixels, so colored backgrounds are left untouched. (4) Manually test with sample uploads (dark-outlined art, white-highlighted art) to confirm no holes are punched in interior details.
@@ -75,3 +67,5 @@ Instructions for agent: This file is the task inventory only. Workflow rules (br
 - [ ] #15 User acquisition strategy: IG account for Meta ads (Bassyndicate audience or promoter lookalike), target market definition (artists, VJs, music lovers) and how to reach them.
 
 ## Discovered
+
+- CLAUDE.md's Commands section says "There is no `test` script yet" — a `test` script (`vitest run`) and 2 test files (14 passing tests) already exist. Found while verifying #16/#17. Update CLAUDE.md's Commands section to reflect this.

--- a/docs/nightlight-meta.json
+++ b/docs/nightlight-meta.json
@@ -1,5 +1,5 @@
 {
   "nextTaskNumber": 21,
-  "tasksCompleted": 1,
+  "tasksCompleted": 3,
   "tasksBlocked": 0
 }

--- a/docs/tasks-archive/2026-08-06.md
+++ b/docs/tasks-archive/2026-08-06.md
@@ -1,0 +1,11 @@
+# Completed 2026-08-06
+
+- #16 [stack: solo] Fix lint toolchain break — bump eslint for @typescript-eslint 8.x compatibility.
+  PR: #151
+  Notes: Bumped `eslint` `^6.8.0` -> `^8.57.0` and `eslint-plugin-jsdoc` `^22.1.0` -> `^48.11.0` (the only other dependency with an eslint-8-incompatible peer range; `babel-eslint`/`eslint-scope`/`eslint-plugin-prefer-arrow` needed no changes). Also added `--ext .ts,.tsx` to the `lint` script — ESLint's default extension matching is `.js` only, so `yarn lint` was silently linting zero files even before the toolchain broke. Removed `jsdoc/newline-after-description` from `.eslintrc` (removed upstream after eslint-plugin-jsdoc v22). Fixed ~65 lint errors surfaced once linting actually ran against `src/`: converted several named function declarations to arrow consts (`prefer-arrow/prefer-arrow-functions`), renamed two locals shadowing module-level orbit params in `hopalong-visualizer.ts` (`no-shadow`), and dropped two dead `eslint-disable-line react-hooks/exhaustive-deps` comments (that plugin was never installed; eslint 8 now flags the unknown rule reference instead of silently ignoring it).
+  NEEDS HUMAN: none.
+
+- #17 [stack: solo] Config popout window UX fixes.
+  PR: #152
+  Notes: Added a `beforeunload` listener on the main `window` in `ConfigWindow.tsx` that closes the popout (mirrors the existing listener on the popout itself). `Sidebar.tsx` now hides `ConfigAccordion` while `configWindowVisible` is true. Added a scoped `.config-window-root .slider-name` font-size override in `Slider.css` so setting-title labels don't wrap in the popout's narrower columns. Popout now opens on a 2nd screen at full `100vh` (width unchanged) via the Window Management API when available/permitted, falling back to today's same-screen sizing otherwise; added ambient types for the API to `src/types/global.d.ts` since it isn't in TS's `lib.dom.d.ts`. Opening the popout became async (awaits screen resolution), which introduced a render-ordering race between root creation and the existing config-sync effect — added an `externalRootReady` flag to force that effect to re-fire once the root actually exists.
+  NEEDS HUMAN: none — Window Management API isn't supported in Firefox/Safari and requires a Chromium permission prompt; unsupported/denied browsers degrade to current single-screen behavior.


### PR DESCRIPTION
## Summary
- Archives completed tasks #16 and #17 to `docs/tasks-archive/2026-08-06.md`, removes them from `TASKS.md`.
- Updates `tasksCompleted` 1 -> 3 in `docs/nightlight-meta.json`.
- Adds one `## Discovered` item: `CLAUDE.md`'s Commands section says no `test` script exists, but `yarn test` (vitest) plus 2 test files (14 passing tests) are already present — found while verifying #16/#17, not fixed here per the "never modify the target repo's CLAUDE.md" rule.

This session completed 2 of the requested tasks (run was capped at 2 for this session); everything else in `TASKS.md` remains open for a future session.

## Test plan
- N/A — docs/task-tracking only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and task-inventory only; no application or runtime code changes.
> 
> **Overview**
> **Task-tracking housekeeping** after overnight agent session work landed in separate PRs (#151, #152).
> 
> Completed items **#16** (eslint toolchain) and **#17** (config popout UX) are removed from `TASKS.md` **Agent-Ready** and recorded in new `docs/tasks-archive/2026-08-06.md` with PR links and implementation notes. `docs/nightlight-meta.json` **`tasksCompleted`** is updated **1 → 3**.
> 
> A new **`## Discovered`** entry notes that `CLAUDE.md` still claims there is no `test` script while `yarn test` (vitest) and tests already exist — documented for a future fix, not changed in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d29bd38fc5b0c8a95a380c668bc49d640502bc08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->