### PR TITLE
feat(particles): auto-strip background from uploaded sprites

### DIFF
--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -41,6 +41,13 @@ const FLAT_IMAGE_COLOR_COVERAGE = 0.92
 const FLAT_IMAGE_COLOR_QUANT_LEVELS = 32
 const INTERIOR_BACKGROUND_MATCH_TOLERANCE = 16
 
+// Textured photo backgrounds (e.g. a brick wall) can have local patches — grout lines, lighting
+// variation — that pass the near-neutral/tolerance gates just enough to nibble a small, irregular
+// bite out of one edge, instead of either cleanly clearing the background or matching nothing. A
+// stripped region that small is more likely that kind of noise than a real background, so below
+// this fraction of the image the whole strip is abandoned and the sprite is left untouched.
+const MIN_STRIP_AREA_FRACTION = 0.03
+
 const isNearNeutral = (r: number, g: number, b: number): boolean => {
   const max = Math.max(r, g, b)
   const min = Math.min(r, g, b)
@@ -191,6 +198,12 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
       queue.push(nIdx)
     }
   }
+
+  let backgroundCount = 0
+  for (let idx = 0; idx < pixelCount; idx++) {
+    if (isBackground[idx]) backgroundCount += 1
+  }
+  if (backgroundCount / pixelCount < MIN_STRIP_AREA_FRACTION) return
 
   const distanceFromForeground = new Int16Array(pixelCount).fill(-1)
   const falloffQueue: number[] = []

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -170,9 +170,17 @@ const prepareSpriteDataUrl = (dataUrl: string, maxSide: number): Promise<string>
       const scale = maxDim > maxSide ? maxSide / maxDim : 1
       const newW = Math.max(1, Math.round(w * scale))
       const newH = Math.max(1, Math.round(h * scale))
+      // The particle renderer draws sprites as THREE.Points, which always billboards each
+      // particle as a square (gl_PointSize is a single scalar and gl_PointCoord samples
+      // [0,1]x[0,1]) — a non-square texture gets stretched to fill that square. So rectangular
+      // uploads are centered on a square, transparent-padded canvas here rather than stretched:
+      // the padding absorbs the square billboard, and the content keeps its original proportions.
+      const side = Math.max(newW, newH)
+      const offsetX = Math.floor((side - newW) / 2)
+      const offsetY = Math.floor((side - newH) / 2)
       const canvas = document.createElement('canvas')
-      canvas.width = newW
-      canvas.height = newH
+      canvas.width = side
+      canvas.height = side
       const ctx = canvas.getContext('2d', { willReadFrequently: true })
       if (!ctx) {
         resolve(dataUrl)
@@ -180,8 +188,8 @@ const prepareSpriteDataUrl = (dataUrl: string, maxSide: number): Promise<string>
       }
       ctx.imageSmoothingEnabled = true
       ctx.imageSmoothingQuality = 'high'
-      ctx.drawImage(img, 0, 0, newW, newH)
-      stripEdgeBackground(ctx, newW, newH)
+      ctx.drawImage(img, offsetX, offsetY, newW, newH)
+      stripEdgeBackground(ctx, side, side)
       resolve(canvas.toDataURL('image/png'))
     }
     img.onerror = () => reject(new Error('decode'))

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -45,7 +45,9 @@ const INTERIOR_BACKGROUND_MATCH_TOLERANCE = 16
 // variation — that pass the near-neutral/tolerance gates just enough to nibble a small, irregular
 // bite out of one edge, instead of either cleanly clearing the background or matching nothing. A
 // stripped region that small is more likely that kind of noise than a real background, so below
-// this fraction of the image the whole strip is abandoned and the sprite is left untouched.
+// this fraction of the *original opaque content* (excluding any transparent square padding, which
+// isn't real content and shouldn't count either way) the whole strip is abandoned and the sprite
+// is left untouched.
 const MIN_STRIP_AREA_FRACTION = 0.03
 
 const isNearNeutral = (r: number, g: number, b: number): boolean => {
@@ -95,6 +97,18 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
   const seeded = new Uint8Array(pixelCount)
   const drift = new Uint16Array(pixelCount)
   const queue: number[] = []
+
+  // Rectangular uploads arrive here already sitting on transparent square padding (see
+  // prepareSpriteDataUrl) — that padding is deliberate and shouldn't count as "background removed"
+  // one way or the other, so the area-fraction sanity check below is measured only against pixels
+  // that started out opaque (the real photo content), not the full padded canvas.
+  const wasOriginallyOpaque = new Uint8Array(pixelCount)
+  let originalOpaqueCount = 0
+  for (let idx = 0; idx < pixelCount; idx++) {
+    if ((data[idx * 4 + 3] ?? 0) === 0) continue
+    wasOriginallyOpaque[idx] = 1
+    originalOpaqueCount += 1
+  }
 
   let bgColorSumR = 0
   let bgColorSumG = 0
@@ -199,11 +213,11 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
     }
   }
 
-  let backgroundCount = 0
+  let strippedContentCount = 0
   for (let idx = 0; idx < pixelCount; idx++) {
-    if (isBackground[idx]) backgroundCount += 1
+    if (isBackground[idx] && wasOriginallyOpaque[idx]) strippedContentCount += 1
   }
-  if (backgroundCount / pixelCount < MIN_STRIP_AREA_FRACTION) return
+  if (originalOpaqueCount === 0 || strippedContentCount / originalOpaqueCount < MIN_STRIP_AREA_FRACTION) return
 
   const distanceFromForeground = new Int16Array(pixelCount).fill(-1)
   const falloffQueue: number[] = []

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -13,24 +13,156 @@ const MAX_DATA_URL_BYTES = 2 * 1024 * 1024
 const SPRITE_MAX_SIDE_PX = 512
 const UPLOAD_ERROR_DISPLAY_MS = 4000
 
+// Background-strip tuning: NEUTRAL_CHANNEL_SPREAD gates which edge pixels can seed the fill
+// (near-black/gray/white only, so colored backgrounds are left alone); FLOOD_FILL_STEP_TOLERANCE
+// bounds how far a pixel's color may drift from the already-filled neighbor that reached it,
+// so gradients/compression noise get absorbed but a hard-edge outline stops the fill cold;
+// FALLOFF_RADIUS_PX is how many background pixels near that stopping edge get a soft alpha
+// ramp instead of a hard 0/255 cutoff.
+const NEUTRAL_CHANNEL_SPREAD = 20
+const FLOOD_FILL_STEP_TOLERANCE = 24
+const FALLOFF_RADIUS_PX = 3
+
+const isNearNeutral = (r: number, g: number, b: number): boolean => {
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  return max - min <= NEUTRAL_CHANNEL_SPREAD
+}
+
+// Flood-fills inward from the canvas edges, removing only pixels reachable from a near-neutral
+// border through a chain of locally-similar neighbors, then feathers the resulting cut edge
+// with a short alpha falloff instead of leaving a hard binary mask.
+const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, height: number): void => {
+  const imageData = ctx.getImageData(0, 0, width, height)
+  const { data } = imageData
+  const pixelCount = width * height
+  const isBackground = new Uint8Array(pixelCount)
+  const seeded = new Uint8Array(pixelCount)
+  const queue: number[] = []
+
+  const enqueueIfBackground = (idx: number): void => {
+    if (seeded[idx]) return
+    const p = idx * 4
+    const isTransparent = (data[p + 3] ?? 0) === 0
+    if (!isTransparent && !isNearNeutral(data[p] ?? 0, data[p + 1] ?? 0, data[p + 2] ?? 0)) return
+    seeded[idx] = 1
+    isBackground[idx] = 1
+    queue.push(idx)
+  }
+
+  for (let x = 0; x < width; x++) {
+    enqueueIfBackground(x)
+    enqueueIfBackground((height - 1) * width + x)
+  }
+  for (let y = 0; y < height; y++) {
+    enqueueIfBackground(y * width)
+    enqueueIfBackground(y * width + (width - 1))
+  }
+
+  let head = 0
+  while (head < queue.length) {
+    const idx = queue[head] ?? -1
+    head += 1
+    const x = idx % width
+    const y = Math.floor(idx / width)
+    const p = idx * 4
+    const r0 = data[p] ?? 0
+    const g0 = data[p + 1] ?? 0
+    const b0 = data[p + 2] ?? 0
+
+    const neighbors: number[] = []
+    if (x > 0) neighbors.push(idx - 1)
+    if (x < width - 1) neighbors.push(idx + 1)
+    if (y > 0) neighbors.push(idx - width)
+    if (y < height - 1) neighbors.push(idx + width)
+
+    for (const nIdx of neighbors) {
+      if (seeded[nIdx]) continue
+      const np = nIdx * 4
+      if ((data[np + 3] ?? 0) === 0) {
+        seeded[nIdx] = 1
+        isBackground[nIdx] = 1
+        queue.push(nIdx)
+        continue
+      }
+      const nr = data[np] ?? 0
+      const ng = data[np + 1] ?? 0
+      const nb = data[np + 2] ?? 0
+      const step = Math.max(Math.abs(nr - r0), Math.abs(ng - g0), Math.abs(nb - b0))
+      if (step <= FLOOD_FILL_STEP_TOLERANCE) {
+        seeded[nIdx] = 1
+        isBackground[nIdx] = 1
+        queue.push(nIdx)
+      }
+    }
+  }
+
+  const distanceFromForeground = new Int16Array(pixelCount).fill(-1)
+  const falloffQueue: number[] = []
+  for (let idx = 0; idx < pixelCount; idx++) {
+    if (!isBackground[idx]) continue
+    const x = idx % width
+    const y = Math.floor(idx / width)
+    const touchesForeground =
+      (x > 0 && !isBackground[idx - 1]) ||
+      (x < width - 1 && !isBackground[idx + 1]) ||
+      (y > 0 && !isBackground[idx - width]) ||
+      (y < height - 1 && !isBackground[idx + width])
+    if (touchesForeground) {
+      distanceFromForeground[idx] = 0
+      falloffQueue.push(idx)
+    }
+  }
+  let fHead = 0
+  while (fHead < falloffQueue.length) {
+    const idx = falloffQueue[fHead] ?? -1
+    fHead += 1
+    const d = distanceFromForeground[idx] ?? -1
+    if (d >= FALLOFF_RADIUS_PX - 1) continue
+    const x = idx % width
+    const y = Math.floor(idx / width)
+    const neighbors: number[] = []
+    if (x > 0) neighbors.push(idx - 1)
+    if (x < width - 1) neighbors.push(idx + 1)
+    if (y > 0) neighbors.push(idx - width)
+    if (y < height - 1) neighbors.push(idx + width)
+    for (const nIdx of neighbors) {
+      if (!isBackground[nIdx]) continue
+      if ((distanceFromForeground[nIdx] ?? -1) !== -1) continue
+      distanceFromForeground[nIdx] = d + 1
+      falloffQueue.push(nIdx)
+    }
+  }
+
+  for (let idx = 0; idx < pixelCount; idx++) {
+    if (!isBackground[idx]) continue
+    const p = idx * 4
+    const d = distanceFromForeground[idx] ?? -1
+    const origAlpha = data[p + 3] ?? 0
+    data[p + 3] = d === -1 ? 0 : Math.round((origAlpha * (FALLOFF_RADIUS_PX - d)) / (FALLOFF_RADIUS_PX + 1))
+  }
+
+  ctx.putImageData(imageData, 0, 0)
+}
+
 const prepareSpriteDataUrl = (dataUrl: string, maxSide: number): Promise<string> => {
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.onload = () => {
       const w = img.naturalWidth
       const h = img.naturalHeight
-      const maxDim = Math.max(w, h)
-      if (maxDim <= maxSide || maxDim === 0) {
+      if (w === 0 || h === 0) {
         resolve(dataUrl)
         return
       }
-      const scale = maxSide / maxDim
+      const maxDim = Math.max(w, h)
+      const scale = maxDim > maxSide ? maxSide / maxDim : 1
       const newW = Math.max(1, Math.round(w * scale))
       const newH = Math.max(1, Math.round(h * scale))
       const canvas = document.createElement('canvas')
       canvas.width = newW
       canvas.height = newH
-      const ctx = canvas.getContext('2d')
+      const ctx = canvas.getContext('2d', { willReadFrequently: true })
       if (!ctx) {
         resolve(dataUrl)
         return
@@ -38,6 +170,7 @@ const prepareSpriteDataUrl = (dataUrl: string, maxSide: number): Promise<string>
       ctx.imageSmoothingEnabled = true
       ctx.imageSmoothingQuality = 'high'
       ctx.drawImage(img, 0, 0, newW, newH)
+      stripEdgeBackground(ctx, newW, newH)
       resolve(canvas.toDataURL('image/png'))
     }
     img.onerror = () => reject(new Error('decode'))

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -16,11 +16,15 @@ const UPLOAD_ERROR_DISPLAY_MS = 4000
 // Background-strip tuning: NEUTRAL_CHANNEL_SPREAD gates which edge pixels can seed the fill
 // (near-black/gray/white only, so colored backgrounds are left alone); FLOOD_FILL_STEP_TOLERANCE
 // bounds how far a pixel's color may drift from the already-filled neighbor that reached it,
-// so gradients/compression noise get absorbed but a hard-edge outline stops the fill cold;
-// FALLOFF_RADIUS_PX is how many background pixels near that stopping edge get a soft alpha
-// ramp instead of a hard 0/255 cutoff.
+// so a single anti-aliased/noisy step gets absorbed but a hard-edge outline stops the fill cold.
+// FLOOD_FILL_MAX_DRIFT bounds the *total* drift accumulated over the whole chain of hops back to
+// the border seed — without it, many small sub-tolerance steps can chain together and worm past
+// a real outline into an interior region that happens to share a similar tone. FALLOFF_RADIUS_PX
+// is how many background pixels near the stopping edge get a soft alpha ramp instead of a hard
+// 0/255 cutoff.
 const NEUTRAL_CHANNEL_SPREAD = 20
-const FLOOD_FILL_STEP_TOLERANCE = 24
+const FLOOD_FILL_STEP_TOLERANCE = 10
+const FLOOD_FILL_MAX_DRIFT = 24
 const FALLOFF_RADIUS_PX = 3
 
 const isNearNeutral = (r: number, g: number, b: number): boolean => {
@@ -38,6 +42,7 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
   const pixelCount = width * height
   const isBackground = new Uint8Array(pixelCount)
   const seeded = new Uint8Array(pixelCount)
+  const drift = new Uint16Array(pixelCount)
   const queue: number[] = []
 
   const enqueueIfBackground = (idx: number): void => {
@@ -47,6 +52,7 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
     if (!isTransparent && !isNearNeutral(data[p] ?? 0, data[p + 1] ?? 0, data[p + 2] ?? 0)) return
     seeded[idx] = 1
     isBackground[idx] = 1
+    drift[idx] = 0
     queue.push(idx)
   }
 
@@ -76,12 +82,15 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
     if (y > 0) neighbors.push(idx - width)
     if (y < height - 1) neighbors.push(idx + width)
 
+    const currentDrift = drift[idx] ?? 0
+
     for (const nIdx of neighbors) {
       if (seeded[nIdx]) continue
       const np = nIdx * 4
       if ((data[np + 3] ?? 0) === 0) {
         seeded[nIdx] = 1
         isBackground[nIdx] = 1
+        drift[nIdx] = currentDrift
         queue.push(nIdx)
         continue
       }
@@ -89,11 +98,13 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
       const ng = data[np + 1] ?? 0
       const nb = data[np + 2] ?? 0
       const step = Math.max(Math.abs(nr - r0), Math.abs(ng - g0), Math.abs(nb - b0))
-      if (step <= FLOOD_FILL_STEP_TOLERANCE) {
-        seeded[nIdx] = 1
-        isBackground[nIdx] = 1
-        queue.push(nIdx)
-      }
+      if (step > FLOOD_FILL_STEP_TOLERANCE) continue
+      const newDrift = currentDrift + step
+      if (newDrift > FLOOD_FILL_MAX_DRIFT) continue
+      seeded[nIdx] = 1
+      isBackground[nIdx] = 1
+      drift[nIdx] = newDrift
+      queue.push(nIdx)
     }
   }
 

--- a/src/components/huds/ParticleSpriteHud.tsx
+++ b/src/components/huds/ParticleSpriteHud.tsx
@@ -27,10 +27,54 @@ const FLOOD_FILL_STEP_TOLERANCE = 10
 const FLOOD_FILL_MAX_DRIFT = 24
 const FALLOFF_RADIUS_PX = 3
 
+// Interior-hole tuning: border-only seeding can't remove a background-colored pocket that's fully
+// enclosed by foreground (e.g. the loop of a cursive letter) without risking a same-colored subject
+// region (an eye on a black background, a gray shirt on a gray background) — color distance alone
+// can't tell those apart. FLAT_IMAGE_COLOR_COVERAGE gates this: it's only safe to also seed interior
+// pixels when the whole image is essentially bilevel line-art/logo (few distinct colors), since that
+// rules out a same-toned subject existing in the first place. FLAT_IMAGE_COLOR_QUANT_LEVELS controls
+// how finely colors are bucketed when checking that. INTERIOR_BACKGROUND_MATCH_TOLERANCE is how close
+// an interior pixel must be to the *learned* border-background color (not just "near-neutral") to be
+// seeded directly, so a flat image's foreground color (also near-neutral, e.g. black ink) isn't swept
+// up just for being grayscale.
+const FLAT_IMAGE_COLOR_COVERAGE = 0.92
+const FLAT_IMAGE_COLOR_QUANT_LEVELS = 32
+const INTERIOR_BACKGROUND_MATCH_TOLERANCE = 16
+
 const isNearNeutral = (r: number, g: number, b: number): boolean => {
   const max = Math.max(r, g, b)
   const min = Math.min(r, g, b)
   return max - min <= NEUTRAL_CHANNEL_SPREAD
+}
+
+// Quantizes every opaque pixel's color and checks whether the two most common buckets cover nearly
+// the whole image — true for bilevel line art/logos/signatures, false for photos and other
+// continuous-tone images where a same-colored subject region could plausibly exist.
+const isFlatImage = (data: Uint8ClampedArray, pixelCount: number): boolean => {
+  const bucketCounts = new Map<number, number>()
+  let opaqueCount = 0
+  for (let idx = 0; idx < pixelCount; idx++) {
+    const p = idx * 4
+    if ((data[p + 3] ?? 0) === 0) continue
+    opaqueCount += 1
+    const rBucket = Math.floor(((data[p] ?? 0) / 256) * FLAT_IMAGE_COLOR_QUANT_LEVELS)
+    const gBucket = Math.floor(((data[p + 1] ?? 0) / 256) * FLAT_IMAGE_COLOR_QUANT_LEVELS)
+    const bBucket = Math.floor(((data[p + 2] ?? 0) / 256) * FLAT_IMAGE_COLOR_QUANT_LEVELS)
+    const key = (rBucket * FLAT_IMAGE_COLOR_QUANT_LEVELS + gBucket) * FLAT_IMAGE_COLOR_QUANT_LEVELS + bBucket
+    bucketCounts.set(key, (bucketCounts.get(key) ?? 0) + 1)
+  }
+  if (opaqueCount === 0) return false
+  let top1 = 0
+  let top2 = 0
+  for (const count of bucketCounts.values()) {
+    if (count > top1) {
+      top2 = top1
+      top1 = count
+    } else if (count > top2) {
+      top2 = count
+    }
+  }
+  return (top1 + top2) / opaqueCount >= FLAT_IMAGE_COLOR_COVERAGE
 }
 
 // Flood-fills inward from the canvas edges, removing only pixels reachable from a near-neutral
@@ -45,14 +89,28 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
   const drift = new Uint16Array(pixelCount)
   const queue: number[] = []
 
+  let bgColorSumR = 0
+  let bgColorSumG = 0
+  let bgColorSumB = 0
+  let bgColorSeedCount = 0
+
   const enqueueIfBackground = (idx: number): void => {
     if (seeded[idx]) return
     const p = idx * 4
+    const r = data[p] ?? 0
+    const g = data[p + 1] ?? 0
+    const b = data[p + 2] ?? 0
     const isTransparent = (data[p + 3] ?? 0) === 0
-    if (!isTransparent && !isNearNeutral(data[p] ?? 0, data[p + 1] ?? 0, data[p + 2] ?? 0)) return
+    if (!isTransparent && !isNearNeutral(r, g, b)) return
     seeded[idx] = 1
     isBackground[idx] = 1
     drift[idx] = 0
+    if (!isTransparent) {
+      bgColorSumR += r
+      bgColorSumG += g
+      bgColorSumB += b
+      bgColorSeedCount += 1
+    }
     queue.push(idx)
   }
 
@@ -63,6 +121,32 @@ const stripEdgeBackground = (ctx: CanvasRenderingContext2D, width: number, heigh
   for (let y = 0; y < height; y++) {
     enqueueIfBackground(y * width)
     enqueueIfBackground(y * width + (width - 1))
+  }
+
+  // Flat/line-art images (few distinct colors, so no same-toned subject can plausibly exist) also
+  // get interior pixels seeded directly whenever they closely match the learned border-background
+  // color — this is what lets a fully-enclosed hole (e.g. the loop of a cursive letter) get removed
+  // even though it never touches the canvas edge. Photographic images skip this and keep the
+  // conservative border-only behavior, since color alone can't tell a hole from a same-colored
+  // subject region (an eye, a shirt) once ML-level semantics are needed.
+  if (bgColorSeedCount > 0 && isFlatImage(data, pixelCount)) {
+    const bgAvgR = bgColorSumR / bgColorSeedCount
+    const bgAvgG = bgColorSumG / bgColorSeedCount
+    const bgAvgB = bgColorSumB / bgColorSeedCount
+    for (let idx = 0; idx < pixelCount; idx++) {
+      if (seeded[idx]) continue
+      const p = idx * 4
+      if ((data[p + 3] ?? 0) === 0) continue
+      const r = data[p] ?? 0
+      const g = data[p + 1] ?? 0
+      const b = data[p + 2] ?? 0
+      const distance = Math.max(Math.abs(r - bgAvgR), Math.abs(g - bgAvgG), Math.abs(b - bgAvgB))
+      if (distance > INTERIOR_BACKGROUND_MATCH_TOLERANCE) continue
+      seeded[idx] = 1
+      isBackground[idx] = 1
+      drift[idx] = 0
+      queue.push(idx)
+    }
   }
 
   let head = 0


### PR DESCRIPTION
## Summary
- Adds edge-inward flood-fill background removal to `prepareSpriteDataUrl()` in `ParticleSpriteHud.tsx`, alongside the existing client-side resize step, before upload.
- Seeds only from near-neutral (black/gray/white) canvas-border pixels, so colored backgrounds are left untouched.
- Flood fill compares each candidate pixel to the already-filled neighbor that reached it (not the original seed color), so gradual gradients/compression noise are absorbed but a hard-edge outline (e.g. a dark stroke around colored art) stops the fill — interior outlines/highlights are preserved as long as they aren't directly exposed to the border with near-identical color to the background.
- Background pixels near the resulting cut boundary get a short (3px) alpha falloff instead of a hard 0/255 cutoff, avoiding a jagged edge.
- `prepareSpriteDataUrl()` now always rasterizes through canvas (previously it returned the original data URL untouched when no resize was needed) so background stripping and PNG/alpha output happen on every upload, not just ones that needed downscaling.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (no changes needed)
- [x] `yarn test` passes (14 existing tests, unrelated to this change)
- [x] `yarn build` succeeds
- [x] Verified the flood-fill/falloff algorithm against synthetic pixel grids (reimplemented standalone in Node, mirroring the TS logic exactly) covering: black background + white outline + red interior + a fully-enclosed black "eye" dot (eye and outline both preserved at full alpha, background removed with a soft falloff ring at the boundary), and a colored (blue) background with yellow interior (all pixels remain fully opaque — colored backgrounds are left untouched)
- [ ] Manual test with a real uploaded sprite in the running app (dev server not exercised in this session — recommend a quick manual upload check of a dark-outlined and a white-highlighted sprite before merge)

No perf issues observed in the synthetic tests at typical sprite sizes; flagging per the task's note that flood-fill perf on up-to-512px sprites is worth watching for upload lag as a follow-up, not a blocker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Heuristic image processing on every upload can alter user assets (false positives/negatives) and adds main-thread canvas work up to 512px; scope is limited to the particle HUD upload path, not server auth or data.
> 
> **Overview**
> Uploaded particle sprites are now **preprocessed on the client** before upload: `prepareSpriteDataUrl()` always rasterizes through canvas (including images already under the size cap) and outputs PNG with alpha.
> 
> **Background removal** (`stripEdgeBackground`) flood-fills inward from the border using only **near-neutral** edge seeds, neighbor-step and cumulative drift limits to stop at hard outlines, and a **3px alpha feather** at the cut. **Flat/line-art** images can also seed interior pixels that match the learned border color to clear enclosed holes; photos stay border-only. If the stripped area is below **3%** of original opaque content, the strip is **skipped** so noisy partial bites are not applied.
> 
> **Layout:** non-square sprites are **centered on a square transparent canvas** (for square `THREE.Points` billboarding) instead of being stretched to a rectangle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa08247c0f4cffe88cce607dddfa966fc97cb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploaded sprites now automatically remove near-neutral backgrounds around their edges.
  * Background removal includes a soft transparency falloff for smoother-looking results.
  * Sprites are placed on transparent square canvases while preserving their original rectangular proportions.
  * Interior background areas in flat images are also detected and removed.

* **Bug Fixes**
  * Sprite preprocessing now consistently applies background cleanup, including to images already within the supported size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->