### PR TITLE
feat(visualization): crossfade particle system on config changes

### DIFF
--- a/docs/stack-notes/user-platform.md
+++ b/docs/stack-notes/user-platform.md
@@ -1,0 +1,85 @@
+# user-platform
+
+## #2 Add crossfade for preset switching
+
+Branch: overnight/2026-08-07/02-particle-crossfade
+
+### Hard-reset trigger (confirmed)
+
+`HopalongManager.particleConfigChanged()` (`src/visualization/hopalong-manager.ts`) polls
+`window.config.particle` every frame against the live `HopalongVisualizer` instance's own
+fields. Any drift (particle count/layers/levels/saturation/size, or a new `sprites` array
+reference) used to call `resetVisualization()`, which synchronously destroyed the whole
+`HopalongVisualizer` (disposing its scene) and constructed+initialized a brand new one on
+the same frame — one frame with the old particle system gone and the new one not yet drawn.
+This is the *only* hard-reset path in the app; per `README.md` it's specific to the Particle
+Config category (orbit/user/effects changes mutate in place, no full rebuild). Since preset
+switching (`retrieveConfigPreset`/`resetConfig` in `ConfigProvider.tsx`) writes a whole new
+`window.config`, it routes through this same path whenever the incoming preset's particle
+section differs from the current one.
+
+### Implementation
+
+All in `src/visualization/hopalong-manager.ts`. `resetVisualization()` is replaced by:
+
+- `startCrossfade()` — constructs the new (`incoming`) `HopalongVisualizer`, and reparents
+  the *outgoing* visualizer's particle `Points` objects into `incoming.scene` via
+  `THREE.Object3D#add()` (which moves rather than copies). `this.hopalongVisualizer` flips to
+  `incoming` immediately so config-diffing, camera, and `update()` calls all target it from
+  the next line onward. `setupEffects()` is re-run so the `EffectComposer`'s `RenderPass`
+  points at the new (now-combined) live scene — same call the old code made, no new pass
+  wiring needed, since crossfading is just an opacity tween on objects that already live in
+  one scene together.
+- `advanceCrossfade(deltaTime)` — runs every frame while a fade is active: tweens outgoing
+  opacity `1→0` and incoming opacity `0→1` linearly over `PARTICLE_CROSSFADE_DURATION_MS`,
+  via `setParticleOpacity()` (sets `.myMaterial.opacity`; materials are already
+  `transparent: true` from construction). Both the outgoing and incoming visualizers keep
+  receiving `update(deltaTime, audioData)` during the fade, so the old particles keep
+  animating/rotating rather than freezing mid-fade.
+- `finalizeCrossfade()` — once `t >= 1`, moves the outgoing objects *back* into the outgoing
+  visualizer's own (unrendered) scene, then calls its existing `destroyVisualization()`. This
+  reuses `HopalongVisualizer`'s own tested `disposeScene`/`disposeMaterial` traversal instead
+  of duplicating geometry/material/texture disposal logic in the manager, and avoids leaking
+  the outgoing particle objects into the live scene permanently.
+- If a second particle-config change lands mid-fade, `startCrossfade()` finalizes the
+  in-progress fade first, then starts a fresh one from the current (possibly
+  partially-faded) incoming visualizer. Verified via a scripted 3-preset-in-a-row switch —
+  no leak, no growth in live scene child count across repeated fades.
+
+`PARTICLE_CROSSFADE_DURATION_MS = 800` added to `src/config/visualizer.config.ts` per the
+task's sub-task 3 (a fixed default for now; a future config-gear task makes it user-configurable).
+
+### `ConfigProvider.tsx` (sub-task 4) — no code change, and why
+
+`retrieveConfigPreset`/`resetConfig` already write straight to `window.config` (synchronously,
+same tick as the React `setConfig`). `HopalongManager.update()` runs on `main.ts`'s own
+`requestAnimationFrame` loop, completely decoupled from React, and polls `window.config` every
+frame — this is the *existing* mechanism every other config mutator in this codebase
+(`updateConfigItem`, `updateParticleSprites`, keyboard handlers) already relies on to reach the
+visualizer. Since the crossfade fix lives inside `particleConfigChanged()`'s own trigger point,
+every caller that mutates `window.config.particle` — presets included — is automatically routed
+through it with no ConfigProvider-side change required. Adding a direct
+ConfigProvider → HopalongManager call would introduce a new coupling across the
+React/Three.js boundary that doesn't exist anywhere else in the codebase and isn't needed here.
+
+### Verified
+
+- `yarn typecheck`, `yarn lint`, `yarn test` all pass.
+- Manual browser verification (Playwright, temporary — not committed): confirmed via a debug
+  hook that `startCrossfade()`/`advanceCrossfade()` run for the full 800ms with correctly
+  complementary opacities (e.g. sampled mid-fade: outgoing 0.109 / incoming 0.891 at
+  713ms/800ms elapsed), and that `finalizeCrossfade()` leaves no orphaned objects in the live
+  scene after 3 consecutive preset switches (children count tracks the current preset's own
+  layer/level count each time, no growth).
+
+### Known deviation / limitation
+
+The task's acceptance criteria ("no frame where the scene hard-resets") is about the particle
+system specifically, matching the README's documented Particle-Config-only warning. Two other
+elements are *not* crossfaded, both pre-existing behavior, out of scope here:
+- **Video plane**: on preset switches that also change `video.clips`, the old plane is
+  disposed and a new one created immediately (`HopalongVisualizer.createVideoPlane`), same as
+  before this task. Video wasn't called out in the acceptance criteria and isn't part of the
+  Particle Config hard-reset the README describes.
+- **Lights**: outgoing's `PointLight`s are not reparented/faded — confirmed harmless since
+  `THREE.PointsMaterial` (used for all particles) is unlit and ignores scene lights entirely.

--- a/docs/stack-notes/user-platform.md
+++ b/docs/stack-notes/user-platform.md
@@ -20,7 +20,12 @@ section differs from the current one.
 
 ### Implementation
 
-All in `src/visualization/hopalong-manager.ts`. `resetVisualization()` is replaced by:
+Mainly in `src/visualization/hopalong-manager.ts`, with a sprite-texture cache added in
+`src/utils/textureCache.ts` (particle systems reuse the same handful of sprite URLs across
+dozens of layer/level objects; caching avoids re-decoding/re-uploading the same texture per
+object) and, later, an equivalent per-object crossfade for Orbit Config changes added to
+`src/visualization/hopalong-visualizer.ts` (see "Later additions" below). `resetVisualization()`
+is replaced by:
 
 - `startCrossfade()` — constructs the new (`incoming`) `HopalongVisualizer`, and reparents
   the *outgoing* visualizer's particle `Points` objects into `incoming.scene` via
@@ -46,8 +51,11 @@ All in `src/visualization/hopalong-manager.ts`. `resetVisualization()` is replac
   partially-faded) incoming visualizer. Verified via a scripted 3-preset-in-a-row switch —
   no leak, no growth in live scene child count across repeated fades.
 
-`PARTICLE_CROSSFADE_DURATION_MS = 800` added to `src/config/visualizer.config.ts` per the
-task's sub-task 3 (a fixed default for now; a future config-gear task makes it user-configurable).
+`PARTICLE_CROSSFADE_DURATION_MS` added to `src/config/visualizer.config.ts` per the task's
+sub-task 3 (a fixed default for now; a future config-gear task makes it user-configurable).
+Tuned during the session to 750ms, paired with `MAX_CROSSFADE_GENERATIONS = 4` (see "Later
+additions") -- 800/1000ms values mentioned elsewhere in this doc are from earlier in
+development and no longer current.
 
 ### `ConfigProvider.tsx` (sub-task 4) — no code change, and why
 
@@ -66,11 +74,12 @@ React/Three.js boundary that doesn't exist anywhere else in the codebase and isn
 
 - `yarn typecheck`, `yarn lint`, `yarn test` all pass.
 - Manual browser verification (Playwright, temporary — not committed): confirmed via a debug
-  hook that `startCrossfade()`/`advanceCrossfade()` run for the full 800ms with correctly
-  complementary opacities (e.g. sampled mid-fade: outgoing 0.109 / incoming 0.891 at
+  hook that `startCrossfade()`/`advanceCrossfade()` ran for the full duration (800ms at the
+  time of this check; the constant was tuned to 750ms afterward, see "Later additions") with
+  correctly complementary opacities (e.g. sampled mid-fade: outgoing 0.109 / incoming 0.891 at
   713ms/800ms elapsed), and that `finalizeCrossfade()` leaves no orphaned objects in the live
   scene after 3 consecutive preset switches (children count tracks the current preset's own
-  layer/level count each time, no growth).
+  layer/level count each time, no growth). Not re-run against later changes below.
 
 ### Known deviation / limitation
 
@@ -83,3 +92,40 @@ elements are *not* crossfaded, both pre-existing behavior, out of scope here:
   Particle Config hard-reset the README describes.
 - **Lights**: outgoing's `PointLight`s are not reparented/faded — confirmed harmless since
   `THREE.PointsMaterial` (used for all particles) is unlit and ignores scene lights entirely.
+
+### Later additions (post-review, same branch)
+
+Review feedback (Cursor Bugbot, CodeRabbit) and follow-up requests surfaced several more
+issues addressed on this branch after the initial implementation above:
+
+- **Sprite texture cache** (`src/utils/textureCache.ts`): particle systems reuse a handful of
+  sprite URLs across dozens of layer/level objects; each used to get its own `TextureLoader`
+  call. Refcounted cache reuses one GPU upload per unique URL — fixed the worst-case preset
+  lag (`notes`/`noteExplosion`, which re-decoded/re-uploaded oversized sprites 40x per switch).
+- **Orbit Config crossfade** (`HopalongVisualizer`): orbit slider changes (`a`-`e`,
+  `scaleFactor`) previously overwrote particle position buffers directly, snapping instantly —
+  the same jarring jump the Particle Config crossfade above was built to avoid, just via a
+  separate code path (`updateOrbit()`'s own poll interval, never routed through
+  `HopalongManager`). Now uses the identical double-buffer opacity technique, scoped to one
+  visualizer's own objects: `startOrbitFade()`/`advanceOrbitFade()`/`finalizeOutgoingOrbitFade()`.
+- **Crossfade generation cap**: both crossfades now support up to `MAX_CROSSFADE_GENERATIONS`
+  (4) concurrent generations — 1 incoming + up to 3 still-fading outgoing, each fading
+  independently — instead of always truncating an in-flight fade the instant another change
+  landed. Tuned alongside `updateOrbit()`'s poll interval (250ms) and
+  `PARTICLE_CROSSFADE_DURATION_MS` (750ms) so 3 outgoing slots exactly cover a full fade
+  (3 × 250ms = 750ms) with no truncation gap.
+- **Outgoing visualizer bugs fixed during review**: outgoing visualizers kept polling
+  `window.config` and reshaping themselves around the *incoming* preset's values mid-fade
+  (`freezeConfig()` now stops this); a spurious orbit fade fired on every new visualizer's
+  first `updateOrbit()` tick because `lastOrbitParams` started `null` (now seeded from live
+  config at construction); `scaleFactor` changes lost their compensating Z-depth shift when
+  orbit changes became a crossfade (reinstated in `startOrbitFade()`); the outgoing side of a
+  particle crossfade kept its old `<video>` element playing/audible for the full fade
+  duration since only particle `Points` were reparented (now torn down in `freezeConfig()`);
+  `setupEffects()` rebuilt `EffectComposer` on every crossfade without disposing the previous
+  one, leaking render targets on every Particle Config drag tick (now disposed first).
+- **Opacity easing tried and reverted**: a quadratic ease (`t²` / `(1-t)²`) was tried to fix a
+  perceived "snaps to 100%" look on additive-blended particles, but broke the
+  `incomingOpacity + outgoingOpacity = 1` invariant linear crossfading has — `t² + (1-t)²`
+  dips to 0.5 at the midpoint, causing a visible mid-fade dim and end-of-fade flash, which was
+  worse than the original front-loaded-but-smooth linear fade. Reverted back to plain linear.

--- a/src/config/visualizer.config.ts
+++ b/src/config/visualizer.config.ts
@@ -8,7 +8,7 @@ export const visualizerConfig = {
 } as const
 
 /** Default crossfade duration (ms) used when Particle Config or Orbit Config changes force a particle-system rebuild. */
-export const PARTICLE_CROSSFADE_DURATION_MS = 1000
+export const PARTICLE_CROSSFADE_DURATION_MS = 750
 
 /**
  * Max particle-system generations allowed alive at once during a crossfade -- 1 current

--- a/src/config/visualizer.config.ts
+++ b/src/config/visualizer.config.ts
@@ -7,5 +7,14 @@ export const visualizerConfig = {
   shockwave: true,
 } as const
 
-/** Default crossfade duration (ms) used when Particle Config changes force a particle-system rebuild. */
+/** Default crossfade duration (ms) used when Particle Config or Orbit Config changes force a particle-system rebuild. */
 export const PARTICLE_CROSSFADE_DURATION_MS = 1000
+
+/**
+ * Max particle-system generations allowed alive at once during a crossfade -- 1 current
+ * (incoming) generation plus up to this-many-minus-1 older generations still fading out.
+ * Applies to both the Particle Config crossfade (HopalongManager) and the Orbit Config
+ * crossfade (HopalongVisualizer). Once a new change would exceed this cap, the oldest
+ * still-fading generation is force-finished immediately to make room.
+ */
+export const MAX_CROSSFADE_GENERATIONS = 4

--- a/src/config/visualizer.config.ts
+++ b/src/config/visualizer.config.ts
@@ -8,4 +8,4 @@ export const visualizerConfig = {
 } as const
 
 /** Default crossfade duration (ms) used when Particle Config changes force a particle-system rebuild. */
-export const PARTICLE_CROSSFADE_DURATION_MS = 800
+export const PARTICLE_CROSSFADE_DURATION_MS = 1000

--- a/src/config/visualizer.config.ts
+++ b/src/config/visualizer.config.ts
@@ -6,3 +6,6 @@ export const visualizerConfig = {
   glow: true,
   shockwave: true,
 } as const
+
+/** Default crossfade duration (ms) used when Particle Config changes force a particle-system rebuild. */
+export const PARTICLE_CROSSFADE_DURATION_MS = 800

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -1,0 +1,8 @@
+/**
+ * Crossfade opacity is linear in time, but additive-blended particles don't read that way:
+ * overlapping points compound brightness, and human vision's gamma response means even a small
+ * linear opacity already looks like most of the way to full brightness. Squaring the progress
+ * compensates -- opacity climbs slowly at first and accelerates near the end, matching how the
+ * fade actually looks rather than how the number moves.
+ */
+export const easeInQuad = (t: number): number => t * t

--- a/src/utils/easing.ts
+++ b/src/utils/easing.ts
@@ -1,8 +1,0 @@
-/**
- * Crossfade opacity is linear in time, but additive-blended particles don't read that way:
- * overlapping points compound brightness, and human vision's gamma response means even a small
- * linear opacity already looks like most of the way to full brightness. Squaring the progress
- * compensates -- opacity climbs slowly at first and accelerates near the end, matching how the
- * fade actually looks rather than how the number moves.
- */
-export const easeInQuad = (t: number): number => t * t

--- a/src/utils/textureCache.ts
+++ b/src/utils/textureCache.ts
@@ -1,0 +1,63 @@
+import * as THREE from 'three'
+
+const FALLBACK_SPRITE_URL = '/fractaleye.png'
+
+type CacheEntry = {
+  texture: THREE.Texture
+  refCount: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const urlByTexture = new WeakMap<THREE.Texture, string>()
+
+// TextureLoader.load() fails asynchronously via its onError callback (e.g. a CORS-blocked
+// R2 request never fires onLoad) -- a try/catch around .load() can't see that. Catch it here
+// and fall back to the bundled sprite so a bad sprite URL doesn't leave particles blank.
+const loadTexture = (url: string): THREE.Texture => {
+  const texture = new THREE.TextureLoader().load(url, undefined, undefined, (error) => {
+    console.warn(`Failed to load particle sprite "${url}", falling back to default`, error)
+    new THREE.TextureLoader().load(FALLBACK_SPRITE_URL, (fallback) => {
+      texture.image = fallback.image
+      texture.needsUpdate = true
+    })
+  })
+  return texture
+}
+
+/**
+ * A single preset spreads a handful of sprite URLs across dozens of layer/level particle
+ * systems, and mid-crossfade the outgoing and incoming visualizer can both be pointing at the
+ * same URL at once -- so textures are refcounted rather than owned by one material, and are
+ * only disposed (freeing the GPU upload) once every acquirer has released it.
+ */
+export const acquireSpriteTexture = (url: string): THREE.Texture => {
+  const existing = cache.get(url)
+  if (existing) {
+    existing.refCount++
+    return existing.texture
+  }
+
+  const texture = loadTexture(url)
+  cache.set(url, { texture, refCount: 1 })
+  urlByTexture.set(texture, url)
+  return texture
+}
+
+/** Releases one reference to a texture acquired via `acquireSpriteTexture`, disposing it once unused. Safe to call on any texture -- one not tracked by the cache is disposed directly. */
+export const releaseSpriteTexture = (texture: THREE.Texture): void => {
+  const url = urlByTexture.get(texture)
+  if (!url) {
+    texture.dispose()
+    return
+  }
+
+  const entry = cache.get(url)
+  if (!entry) return
+
+  entry.refCount--
+  if (entry.refCount <= 0) {
+    entry.texture.dispose()
+    cache.delete(url)
+    urlByTexture.delete(texture)
+  }
+}

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -146,7 +146,10 @@ export class HopalongManager {
   startCrossfade = (): void => {
     if (this.crossfade) {
       // Another particle config change landed mid-fade -- finish the current fade
-      // immediately rather than stacking a second outgoing visualizer.
+      // immediately rather than stacking a second outgoing visualizer, and snap the
+      // in-progress visualizer to full opacity first so it starts its own fade-out from
+      // fully visible instead of wherever its fade-in had gotten to.
+      this.setParticleOpacity(this.hopalongVisualizer!, 1)
       this.finalizeCrossfade()
     }
 

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -5,6 +5,7 @@ import { HopalongVisualizer } from './hopalong-visualizer'
 import { CameraManager } from './camera-manager'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
 import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
+import { easeInQuad } from '../utils/easing'
 
 type ParticleCrossfade = {
   outgoing: HopalongVisualizer
@@ -185,13 +186,13 @@ export class HopalongManager {
   advanceCrossfades = (deltaTime: number): void => {
     if (this.incomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
       this.incomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.incomingElapsedMs + deltaTime)
-      this.setParticleOpacity(this.hopalongVisualizer!, this.incomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
+      this.setParticleOpacity(this.hopalongVisualizer!, easeInQuad(this.incomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS))
     }
 
     this.crossfades = this.crossfades.filter((cf) => {
       cf.elapsedMs += deltaTime
       const t = Math.min(1, cf.elapsedMs / cf.durationMs)
-      this.setParticleOpacity(cf.outgoing, 1 - t)
+      this.setParticleOpacity(cf.outgoing, easeInQuad(1 - t))
       if (t < 1) return true
       this.finalizeOutgoing(cf)
       return false

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -71,6 +71,11 @@ export class HopalongManager {
   }
 
   setupEffects = (): void => {
+    // Rebuilt on every crossfade start (to point the RenderPass at the new scene) -- without
+    // disposing the previous one first, each rebuild leaked its render targets/passes, and
+    // since Particle Config drags call startCrossfade() on essentially every frame, that leak
+    // compounded fast.
+    this.composer?.dispose()
     this.composer = new EffectComposer(this.renderer!)
     this.composer.addPass(new RenderPass(this.hopalongVisualizer!.getScene(), this.cameraManager!.getCamera()))
     this.bloomEffect = new BloomEffect()

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -154,6 +154,11 @@ export class HopalongManager {
     }
 
     const outgoing = this.hopalongVisualizer!
+    // window.config already reflects the incoming preset by the time this runs, and outgoing
+    // still polls it (updateOrbit()'s interval, switcheroo's regenerate) -- freeze it so it
+    // fades out its own last shape instead of reshaping itself around the new preset's orbit
+    // params mid-fade.
+    outgoing.freezeConfig()
     const incoming = new HopalongVisualizer()
     incoming.init()
 

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -5,7 +5,6 @@ import { HopalongVisualizer } from './hopalong-visualizer'
 import { CameraManager } from './camera-manager'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
 import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
-import { easeInQuad } from '../utils/easing'
 
 type ParticleCrossfade = {
   outgoing: HopalongVisualizer
@@ -186,13 +185,13 @@ export class HopalongManager {
   advanceCrossfades = (deltaTime: number): void => {
     if (this.incomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
       this.incomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.incomingElapsedMs + deltaTime)
-      this.setParticleOpacity(this.hopalongVisualizer!, easeInQuad(this.incomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS))
+      this.setParticleOpacity(this.hopalongVisualizer!, this.incomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
     }
 
     this.crossfades = this.crossfades.filter((cf) => {
       cf.elapsedMs += deltaTime
       const t = Math.min(1, cf.elapsedMs / cf.durationMs)
-      this.setParticleOpacity(cf.outgoing, easeInQuad(1 - t))
+      this.setParticleOpacity(cf.outgoing, 1 - t)
       if (t < 1) return true
       this.finalizeOutgoing(cf)
       return false

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -4,6 +4,13 @@ import { EffectComposer, ShockWaveEffect, RenderPass, BloomEffect, EffectPass } 
 import { HopalongVisualizer } from './hopalong-visualizer'
 import { CameraManager } from './camera-manager'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
+import { PARTICLE_CROSSFADE_DURATION_MS } from '../config/visualizer.config'
+
+type ParticleCrossfade = {
+  outgoing: HopalongVisualizer
+  elapsedMs: number
+  durationMs: number
+}
 
 export class HopalongManager {
   private elapsedTime: number
@@ -16,6 +23,7 @@ export class HopalongManager {
   private shockwaveEffect: ShockWaveEffect | null
   private effectPass: EffectPass | null
   private lastAudioData: AudioAnalysedDataForVisualization | null
+  private crossfade: ParticleCrossfade | null
 
   constructor() {
     this.elapsedTime = 0
@@ -28,6 +36,7 @@ export class HopalongManager {
     this.bloomEffect = null
     this.shockwaveEffect = null
     this.effectPass = null
+    this.crossfade = null
   }
 
   init = (_startTimer: Date): void => {
@@ -87,9 +96,13 @@ export class HopalongManager {
     ;(this.shockwaveEffect as any).speed = (window.config.user.speed.value / 15) + peakVal * 1.25
 
     if (this.particleConfigChanged()) {
-      this.resetVisualization()
+      this.startCrossfade()
     }
     this.hopalongVisualizer!.update(deltaTime, audioData)
+    if (this.crossfade) {
+      this.crossfade.outgoing.update(deltaTime, audioData)
+      this.advanceCrossfade(deltaTime)
+    }
 
     if (window.config.effects.glow.value && audioData.peak) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,11 +137,57 @@ export class HopalongManager {
     return hasChanged
   }
 
-  resetVisualization = (): void => {
-    this.hopalongVisualizer!.destroyVisualization()
-    this.hopalongVisualizer = new HopalongVisualizer()
-    this.hopalongVisualizer.init()
+  /**
+   * Particle Config changes require rebuilding the particle system from scratch (new
+   * geometry/material per particle), so we can't tween the old system into the new one --
+   * instead run both simultaneously, reparented into the same live scene, and crossfade
+   * their opacity so there's never a frame where particles are just gone.
+   */
+  startCrossfade = (): void => {
+    if (this.crossfade) {
+      // Another particle config change landed mid-fade -- finish the current fade
+      // immediately rather than stacking a second outgoing visualizer.
+      this.finalizeCrossfade()
+    }
+
+    const outgoing = this.hopalongVisualizer!
+    const incoming = new HopalongVisualizer()
+    incoming.init()
+
+    // THREE.Object3D#add() reparents automatically, moving these out of outgoing's scene.
+    outgoing.objects.forEach((obj) => incoming.scene.add(obj))
+    this.setParticleOpacity(incoming, 0)
+
+    this.hopalongVisualizer = incoming
+    this.crossfade = { outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS }
     this.setupEffects()
+  }
+
+  advanceCrossfade = (deltaTime: number): void => {
+    const cf = this.crossfade!
+    cf.elapsedMs += deltaTime
+    const t = Math.min(1, cf.elapsedMs / cf.durationMs)
+    this.setParticleOpacity(cf.outgoing, 1 - t)
+    this.setParticleOpacity(this.hopalongVisualizer!, t)
+    if (t >= 1) {
+      this.finalizeCrossfade()
+    }
+  }
+
+  finalizeCrossfade = (): void => {
+    const cf = this.crossfade!
+    // Move the outgoing particle systems back into their own (unrendered) scene so
+    // outgoing.destroyVisualization()'s disposeScene() can dispose their geometry/material/
+    // textures through its existing traversal, instead of duplicating that logic here.
+    cf.outgoing.objects.forEach((obj) => cf.outgoing.scene.add(obj))
+    cf.outgoing.destroyVisualization()
+    this.crossfade = null
+  }
+
+  setParticleOpacity = (visualizer: HopalongVisualizer, opacity: number): void => {
+    visualizer.objects.forEach((obj) => {
+      obj.myMaterial.opacity = opacity
+    })
   }
 
   onDocumentMouseMove = (event: MouseEvent): void => {

--- a/src/visualization/hopalong-manager.ts
+++ b/src/visualization/hopalong-manager.ts
@@ -4,7 +4,7 @@ import { EffectComposer, ShockWaveEffect, RenderPass, BloomEffect, EffectPass } 
 import { HopalongVisualizer } from './hopalong-visualizer'
 import { CameraManager } from './camera-manager'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
-import { PARTICLE_CROSSFADE_DURATION_MS } from '../config/visualizer.config'
+import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
 
 type ParticleCrossfade = {
   outgoing: HopalongVisualizer
@@ -23,7 +23,10 @@ export class HopalongManager {
   private shockwaveEffect: ShockWaveEffect | null
   private effectPass: EffectPass | null
   private lastAudioData: AudioAnalysedDataForVisualization | null
-  private crossfade: ParticleCrossfade | null
+  /** Older generations still fading out, oldest first. */
+  private crossfades: ParticleCrossfade[]
+  /** Current (newest) visualizer's own fade-in progress. */
+  private incomingElapsedMs: number
 
   constructor() {
     this.elapsedTime = 0
@@ -36,7 +39,8 @@ export class HopalongManager {
     this.bloomEffect = null
     this.shockwaveEffect = null
     this.effectPass = null
-    this.crossfade = null
+    this.crossfades = []
+    this.incomingElapsedMs = PARTICLE_CROSSFADE_DURATION_MS
   }
 
   init = (_startTimer: Date): void => {
@@ -99,10 +103,8 @@ export class HopalongManager {
       this.startCrossfade()
     }
     this.hopalongVisualizer!.update(deltaTime, audioData)
-    if (this.crossfade) {
-      this.crossfade.outgoing.update(deltaTime, audioData)
-      this.advanceCrossfade(deltaTime)
-    }
+    this.crossfades.forEach((cf) => cf.outgoing.update(deltaTime, audioData))
+    this.advanceCrossfades(deltaTime)
 
     if (window.config.effects.glow.value && audioData.peak) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,19 +143,23 @@ export class HopalongManager {
    * Particle Config changes require rebuilding the particle system from scratch (new
    * geometry/material per particle), so we can't tween the old system into the new one --
    * instead run both simultaneously, reparented into the same live scene, and crossfade
-   * their opacity so there's never a frame where particles are just gone.
+   * their opacity so there's never a frame where particles are just gone. Up to
+   * MAX_CROSSFADE_GENERATIONS generations (1 incoming + N-1 still-fading outgoing) can be
+   * alive at once, each fading out independently on its own timeline, rather than always
+   * truncating whatever was fading when the next change lands.
    */
   startCrossfade = (): void => {
-    if (this.crossfade) {
-      // Another particle config change landed mid-fade -- finish the current fade
-      // immediately rather than stacking a second outgoing visualizer, and snap the
-      // in-progress visualizer to full opacity first so it starts its own fade-out from
-      // fully visible instead of wherever its fade-in had gotten to.
-      this.setParticleOpacity(this.hopalongVisualizer!, 1)
-      this.finalizeCrossfade()
+    // Adding a new generation would exceed the cap -- force-finish the oldest still-fading
+    // one(s) immediately to make room, rather than growing the list unbounded.
+    while (this.crossfades.length >= MAX_CROSSFADE_GENERATIONS - 1) {
+      this.finalizeOutgoing(this.crossfades.shift()!)
     }
 
     const outgoing = this.hopalongVisualizer!
+    // It may still be mid-fade-in itself -- snap to full opacity before demoting it to an
+    // outgoing generation, so its own fade-out starts from fully visible instead of jumping
+    // from wherever its fade-in had gotten to.
+    this.setParticleOpacity(outgoing, 1)
     // window.config already reflects the incoming preset by the time this runs, and outgoing
     // still polls it (updateOrbit()'s interval, switcheroo's regenerate) -- freeze it so it
     // fades out its own last shape instead of reshaping itself around the new preset's orbit
@@ -162,34 +168,42 @@ export class HopalongManager {
     const incoming = new HopalongVisualizer()
     incoming.init()
 
-    // THREE.Object3D#add() reparents automatically, moving these out of outgoing's scene.
-    outgoing.objects.forEach((obj) => incoming.scene.add(obj))
+    // THREE.Object3D#add() reparents automatically. Every particle object currently alive --
+    // outgoing's own plus every still-fading older generation's -- needs to move into the new
+    // incoming's scene, since that's the only scene the composer's RenderPass points at; a
+    // generation left behind in an intermediate visualizer's scene would stop being rendered.
+    const liveObjects = [outgoing, ...this.crossfades.map((cf) => cf.outgoing)].flatMap((v) => v.objects)
+    liveObjects.forEach((obj) => incoming.scene.add(obj))
     this.setParticleOpacity(incoming, 0)
 
     this.hopalongVisualizer = incoming
-    this.crossfade = { outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS }
+    this.incomingElapsedMs = 0
+    this.crossfades.push({ outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS })
     this.setupEffects()
   }
 
-  advanceCrossfade = (deltaTime: number): void => {
-    const cf = this.crossfade!
-    cf.elapsedMs += deltaTime
-    const t = Math.min(1, cf.elapsedMs / cf.durationMs)
-    this.setParticleOpacity(cf.outgoing, 1 - t)
-    this.setParticleOpacity(this.hopalongVisualizer!, t)
-    if (t >= 1) {
-      this.finalizeCrossfade()
+  advanceCrossfades = (deltaTime: number): void => {
+    if (this.incomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
+      this.incomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.incomingElapsedMs + deltaTime)
+      this.setParticleOpacity(this.hopalongVisualizer!, this.incomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
     }
+
+    this.crossfades = this.crossfades.filter((cf) => {
+      cf.elapsedMs += deltaTime
+      const t = Math.min(1, cf.elapsedMs / cf.durationMs)
+      this.setParticleOpacity(cf.outgoing, 1 - t)
+      if (t < 1) return true
+      this.finalizeOutgoing(cf)
+      return false
+    })
   }
 
-  finalizeCrossfade = (): void => {
-    const cf = this.crossfade!
+  finalizeOutgoing = (cf: ParticleCrossfade): void => {
     // Move the outgoing particle systems back into their own (unrendered) scene so
     // outgoing.destroyVisualization()'s disposeScene() can dispose their geometry/material/
     // textures through its existing traversal, instead of duplicating that logic here.
     cf.outgoing.objects.forEach((obj) => cf.outgoing.scene.add(obj))
     cf.outgoing.destroyVisualization()
-    this.crossfade = null
   }
 
   setParticleOpacity = (visualizer: HopalongVisualizer, opacity: number): void => {

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -2,27 +2,13 @@ import * as THREE from 'three'
 
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
 import { getResolvedSpriteUrl } from '../utils/spriteCache'
+import { acquireSpriteTexture, releaseSpriteTexture } from '../utils/textureCache'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
  * Modifications made by Cody Douglass and Conor O'Neill
  */
 const DEF_BRIGHTNESS = .5
-const FALLBACK_SPRITE_URL = '/fractaleye.png'
-
-// TextureLoader.load() fails asynchronously via its onError callback (e.g. a CORS-blocked
-// R2 request never fires onLoad) -- a try/catch around .load() can't see that. Catch it here
-// and fall back to the bundled sprite so a bad sprite URL doesn't leave particles blank.
-const loadSpriteTexture = (url: string): THREE.Texture => {
-  const texture = new THREE.TextureLoader().load(url, undefined, undefined, (error) => {
-    console.warn(`Failed to load particle sprite "${url}", falling back to default`, error)
-    new THREE.TextureLoader().load(FALLBACK_SPRITE_URL, (fallback) => {
-      texture.image = fallback.image
-      texture.needsUpdate = true
-    })
-  })
-  return texture
-}
 
 // Orbit parameters
 let a = 0; let b = 0; let c = 0; let d = 0; let e = 0
@@ -112,7 +98,6 @@ export class HopalongVisualizer {
   }
 
   init(): void {
-    let sprite = loadSpriteTexture(getResolvedSpriteUrl(this.sprites[0]!))
     let count = 1
     let particleIndex = 0
     this.setLights()
@@ -135,7 +120,7 @@ export class HopalongVisualizer {
         const geometry = new THREE.BufferGeometry().setFromPoints(points)
 
         particleIndex = count % this.sprites.length
-        sprite = loadSpriteTexture(getResolvedSpriteUrl(this.sprites[particleIndex]!))
+        const sprite = acquireSpriteTexture(getResolvedSpriteUrl(this.sprites[particleIndex]!))
         const material = new THREE.PointsMaterial({
           size: this.particleSize,
           map: sprite,
@@ -471,7 +456,7 @@ export class HopalongVisualizer {
   private disposeMaterial(material: THREE.Material): void {
     for (const v of Object.values(material)) {
       if (v instanceof THREE.Texture) {
-        v.dispose()
+        releaseSpriteTexture(v)
       }
     }
     material.dispose()

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -4,6 +4,7 @@ import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analys
 import { getResolvedSpriteUrl } from '../utils/spriteCache'
 import { acquireSpriteTexture, releaseSpriteTexture } from '../utils/textureCache'
 import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
+import { easeInQuad } from '../utils/easing'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
@@ -420,13 +421,13 @@ export class HopalongVisualizer {
   private advanceOrbitFade(deltaTime: number): void {
     if (this.orbitIncomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
       this.orbitIncomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.orbitIncomingElapsedMs + deltaTime)
-      this.setObjectsOpacity(this.objects, this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
+      this.setObjectsOpacity(this.objects, easeInQuad(this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS))
     }
 
     this.orbitFades = this.orbitFades.filter((fade) => {
       fade.elapsedMs += deltaTime
       const t = Math.min(1, fade.elapsedMs / fade.durationMs)
-      this.setObjectsOpacity(fade.outgoing, 1 - t)
+      this.setObjectsOpacity(fade.outgoing, easeInQuad(1 - t))
       if (t < 1) return true
       this.finalizeOutgoingOrbitFade(fade)
       return false

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -60,7 +60,7 @@ export class HopalongVisualizer {
   elapsedTime: number
   audioPeak: boolean
   peakCountdown: number
-  lastOrbitParams: { a: number | null; b: number | null; c: number | null; d: number | null; e: number | null; scaleFactor: number | null }
+  lastOrbitParams: { a: number; b: number; c: number; d: number; e: number; scaleFactor: number }
   orbit: { subsets: SubsetPoint[][]; xMin: number; xMax: number; yMin: number; yMax: number; scaleX: number; scaleY: number }
   private updateInterval: ReturnType<typeof setInterval> | undefined
   /** Set once this visualizer becomes the outgoing half of a crossfade, so it stops reshaping
@@ -103,7 +103,16 @@ export class HopalongVisualizer {
     this.elapsedTime = 0
     this.audioPeak = false
     this.peakCountdown = 0
-    this.lastOrbitParams = { a: null, b: null, c: null, d: null, e: null, scaleFactor: null }
+    // Seeded from the live config (not null) so the first updateOrbit() poll after
+    // construction doesn't see a spurious "changed" diff and kick off a needless orbit fade.
+    this.lastOrbitParams = {
+      a: window.config.orbit.a.value,
+      b: window.config.orbit.b.value,
+      c: window.config.orbit.c.value,
+      d: window.config.orbit.d.value,
+      e: window.config.orbit.e.value,
+      scaleFactor: window.config.user.scaleFactor.value
+    }
     this.orbit = { subsets: [], xMin: 0, xMax: 0, yMin: 0, yMax: 0, scaleX: 0, scaleY: 0 }
     this.updateInterval = undefined
     this.frozen = false
@@ -299,7 +308,7 @@ export class HopalongVisualizer {
     })
   }
 
-  private applyParticleMotion(obj: ParticleSystem, count: number, musicSpeedMultiplier: number, applyPeakEffects: boolean): void {
+  private applyParticleMotion = (obj: ParticleSystem, count: number, musicSpeedMultiplier: number, applyPeakEffects: boolean): void => {
     obj.position.z += window.config.user.speed.value * musicSpeedMultiplier
 
     if (applyPeakEffects) {
@@ -350,6 +359,12 @@ export class HopalongVisualizer {
 
     if (!paramsChanged) return
 
+    // Existing particles' Z positions (and the wrap threshold in applyParticleMotion) were
+    // computed relative to the old scaleFactor -- shift them by half the delta so depth/wrap
+    // behavior stays consistent under the new one, same compensation the old in-place
+    // updateOrbit() applied before this became a crossfade.
+    const depthShift = (newScaleFactor - this.lastOrbitParams.scaleFactor) / 2
+
     this.lastOrbitParams = { a: newA, b: newB, c: newC, d: newD, e: newE, scaleFactor: newScaleFactor }
 
     this.generateOrbit()
@@ -358,7 +373,7 @@ export class HopalongVisualizer {
       this.hueValues[s] = Math.random()
     }
 
-    this.startOrbitFade()
+    this.startOrbitFade(depthShift)
   }
 
   /**
@@ -373,7 +388,7 @@ export class HopalongVisualizer {
    * top of the shape change. Up to MAX_CROSSFADE_GENERATIONS generations can be alive at once,
    * each fading out independently, matching HopalongManager's particle crossfade.
    */
-  private startOrbitFade(): void {
+  private startOrbitFade = (depthShift: number): void => {
     // Adding a new generation would exceed the cap -- force-finish the oldest still-fading
     // one(s) immediately to make room, rather than growing the list unbounded.
     while (this.orbitFades.length >= MAX_CROSSFADE_GENERATIONS - 1) {
@@ -405,6 +420,7 @@ export class HopalongVisualizer {
       particles.mySubset = obj.mySubset
       particles.mySpriteUrl = obj.mySpriteUrl
       particles.position.copy(obj.position)
+      particles.position.z += depthShift
       particles.rotation.z = obj.rotation.z
       particles.needsUpdate = 0
       particles.myMaterial.color.setHSL(this.hueValues[obj.mySubset]!, this.saturation, DEF_BRIGHTNESS)
@@ -417,7 +433,7 @@ export class HopalongVisualizer {
     this.orbitFades.push({ outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS })
   }
 
-  private advanceOrbitFade(deltaTime: number): void {
+  private advanceOrbitFade = (deltaTime: number): void => {
     if (this.orbitIncomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
       this.orbitIncomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.orbitIncomingElapsedMs + deltaTime)
       this.setObjectsOpacity(this.objects, this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
@@ -433,7 +449,7 @@ export class HopalongVisualizer {
     })
   }
 
-  private finalizeOutgoingOrbitFade(fade: OrbitFade): void {
+  private finalizeOutgoingOrbitFade = (fade: OrbitFade): void => {
     fade.outgoing.forEach((obj) => {
       this.scene.remove(obj)
       obj.geometry.dispose()
@@ -441,7 +457,7 @@ export class HopalongVisualizer {
     })
   }
 
-  private setObjectsOpacity(objects: ParticleSystem[], opacity: number): void {
+  private setObjectsOpacity = (objects: ParticleSystem[], opacity: number): void => {
     objects.forEach((obj) => {
       obj.myMaterial.opacity = opacity
     })
@@ -541,8 +557,12 @@ export class HopalongVisualizer {
    * is now live in window.config. Also resolves any in-progress orbit-shape fade immediately:
    * once HopalongManager starts driving this visualizer's overall opacity as a single outgoing
    * generation, an unrelated inner fade still animating individual objects' opacity would fight
-   * it for control of the same materials. */
-  freezeConfig(): void {
+   * it for control of the same materials. Tears down any video plane/element too -- only
+   * particle Points get reparented into the incoming visualizer's scene, so an outgoing video
+   * plane is no longer part of what's actually rendered, but its underlying <video> element
+   * would otherwise keep playing (and its audio keeps sounding) until this visualizer is
+   * eventually disposed at the end of its fade. */
+  freezeConfig = (): void => {
     this.frozen = true
     if (this.updateInterval !== undefined) {
       clearInterval(this.updateInterval)
@@ -553,6 +573,8 @@ export class HopalongVisualizer {
       this.orbitFades.forEach((fade) => this.finalizeOutgoingOrbitFade(fade))
       this.orbitFades = []
     }
+    window.removeEventListener('videoClipsRestored', this.onVideoClipsRestored)
+    this.disposeVideoPlane()
   }
 
   disposeVideoPlane(): void {

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -169,7 +169,7 @@ export class HopalongVisualizer {
       }
     }
 
-    this.updateInterval = setInterval(() => { this.updateOrbit() }, 300)
+    this.updateInterval = setInterval(() => { this.updateOrbit() }, 250)
   }
 
   createVideoPlane(clips: string[]): void {

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
 import { getResolvedSpriteUrl } from '../utils/spriteCache'
 import { acquireSpriteTexture, releaseSpriteTexture } from '../utils/textureCache'
-import { PARTICLE_CROSSFADE_DURATION_MS } from '../config/visualizer.config'
+import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
@@ -67,7 +67,10 @@ export class HopalongVisualizer {
    * its orbit from window.config (already overwritten with the incoming preset's values by the
    * time the fade starts) and just fades out its last known shape instead. */
   private frozen: boolean
-  private orbitFade: OrbitFade | null
+  /** Older orbit-shape generations still fading out, oldest first. */
+  private orbitFades: OrbitFade[]
+  /** Current (newest) orbit shape's own fade-in progress. */
+  private orbitIncomingElapsedMs: number
 
   private onVideoClipsRestored = (event: Event): void => {
     const ce = event as CustomEvent<{ clips: string[] }>
@@ -104,7 +107,8 @@ export class HopalongVisualizer {
     this.orbit = { subsets: [], xMin: 0, xMax: 0, yMin: 0, yMax: 0, scaleX: 0, scaleY: 0 }
     this.updateInterval = undefined
     this.frozen = false
-    this.orbitFade = null
+    this.orbitFades = []
+    this.orbitIncomingElapsedMs = PARTICLE_CROSSFADE_DURATION_MS
 
     for (let i = 0; i < this.layers; i++) {
       const subsetPoints: SubsetPoint[] = []
@@ -280,13 +284,16 @@ export class HopalongVisualizer {
 
       this.applyParticleMotion(obj, count, musicSpeedMultiplier, wasAudioPeak)
 
-      // An orbit fade's outgoing objects should keep drifting/rotating/color-shifting just
-      // like they would have without the fade -- only their shape and opacity differ from the
-      // incoming set, so they get the same per-frame motion, paired by index.
-      const outgoingObj = this.orbitFade?.outgoing[index]
-      if (outgoingObj) {
-        this.applyParticleMotion(outgoingObj, count, musicSpeedMultiplier, wasAudioPeak)
-      }
+      // Every still-fading orbit generation's outgoing objects should keep drifting/rotating/
+      // color-shifting just like they would have without the fade -- only their shape and
+      // opacity differ from the incoming set, so they get the same per-frame motion, paired
+      // by index.
+      this.orbitFades.forEach((fade) => {
+        const outgoingObj = fade.outgoing[index]
+        if (outgoingObj) {
+          this.applyParticleMotion(outgoingObj, count, musicSpeedMultiplier, wasAudioPeak)
+        }
+      })
 
       count++
     })
@@ -363,15 +370,20 @@ export class HopalongVisualizer {
    * new orbit shape (this.orbit.subsets was just regenerated above), fade the old set out and the
    * new set in, then dispose the old set. New objects inherit the outgoing object's *current*
    * position/rotation (not the spawn formula) so there's no additional depth/rotation jump on
-   * top of the shape change.
+   * top of the shape change. Up to MAX_CROSSFADE_GENERATIONS generations can be alive at once,
+   * each fading out independently, matching HopalongManager's particle crossfade.
    */
   private startOrbitFade(): void {
-    if (this.orbitFade) {
-      // Another orbit param change landed mid-fade -- finish it immediately rather than
-      // stacking a second outgoing generation (same cap-at-2 pattern as the particle crossfade).
-      this.setObjectsOpacity(this.objects, 1)
-      this.finalizeOrbitFade()
+    // Adding a new generation would exceed the cap -- force-finish the oldest still-fading
+    // one(s) immediately to make room, rather than growing the list unbounded.
+    while (this.orbitFades.length >= MAX_CROSSFADE_GENERATIONS - 1) {
+      this.finalizeOutgoingOrbitFade(this.orbitFades.shift()!)
     }
+
+    // It may still be mid-fade-in itself -- snap to full opacity before demoting it to an
+    // outgoing generation, so its own fade-out starts from fully visible instead of jumping
+    // from wherever its fade-in had gotten to.
+    this.setObjectsOpacity(this.objects, 1)
 
     const outgoing = this.objects
     const incoming: ParticleSystem[] = outgoing.map((obj) => {
@@ -401,28 +413,32 @@ export class HopalongVisualizer {
     })
 
     this.objects = incoming
-    this.orbitFade = { outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS }
+    this.orbitIncomingElapsedMs = 0
+    this.orbitFades.push({ outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS })
   }
 
   private advanceOrbitFade(deltaTime: number): void {
-    const fade = this.orbitFade
-    if (!fade) return
+    if (this.orbitIncomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
+      this.orbitIncomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.orbitIncomingElapsedMs + deltaTime)
+      this.setObjectsOpacity(this.objects, this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
+    }
 
-    fade.elapsedMs += deltaTime
-    const t = Math.min(1, fade.elapsedMs / fade.durationMs)
-    this.setObjectsOpacity(fade.outgoing, 1 - t)
-    this.setObjectsOpacity(this.objects, t)
-    if (t >= 1) this.finalizeOrbitFade()
+    this.orbitFades = this.orbitFades.filter((fade) => {
+      fade.elapsedMs += deltaTime
+      const t = Math.min(1, fade.elapsedMs / fade.durationMs)
+      this.setObjectsOpacity(fade.outgoing, 1 - t)
+      if (t < 1) return true
+      this.finalizeOutgoingOrbitFade(fade)
+      return false
+    })
   }
 
-  private finalizeOrbitFade(): void {
-    const fade = this.orbitFade!
+  private finalizeOutgoingOrbitFade(fade: OrbitFade): void {
     fade.outgoing.forEach((obj) => {
       this.scene.remove(obj)
       obj.geometry.dispose()
       this.disposeMaterial(obj.myMaterial)
     })
-    this.orbitFade = null
   }
 
   private setObjectsOpacity(objects: ParticleSystem[], opacity: number): void {
@@ -532,9 +548,10 @@ export class HopalongVisualizer {
       clearInterval(this.updateInterval)
       this.updateInterval = undefined
     }
-    if (this.orbitFade) {
+    if (this.orbitFades.length > 0) {
       this.setObjectsOpacity(this.objects, 1)
-      this.finalizeOrbitFade()
+      this.orbitFades.forEach((fade) => this.finalizeOutgoingOrbitFade(fade))
+      this.orbitFades = []
     }
   }
 

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -250,16 +250,19 @@ export class HopalongVisualizer {
     let count = 0
     let switcherooGenerated = false
 
-    this.objects.forEach((obj) => {
-      obj.position.z += window.config.user.speed.value * musicSpeedMultiplier
+    this.objects.forEach((obj, index) => {
+      const wasAudioPeak = this.audioPeak
 
-      if (this.audioPeak) {
+      if (wasAudioPeak) {
         this.peakCountdown--
         if (this.peakCountdown <= 0) {
           this.audioPeak = false
           this.peakCountdown = 100
         }
 
+        // Switcheroo reshapes obj's own buffer to the current orbit -- only ever the primary
+        // (incoming) object. Applying it to an in-flight orbit fade's outgoing object would
+        // reshape it into the *new* orbit mid-fade, defeating the crossfade entirely.
         if (count % 2 === 0 && window.config.effects.switcheroo.value && !this.frozen) {
           if (!switcherooGenerated) {
             this.generateOrbit()
@@ -273,31 +276,48 @@ export class HopalongVisualizer {
           }
           obj.geometry.attributes.position!.needsUpdate = true
         }
-
-        if (window.config.effects.wobWob.value) {
-          obj.position.z -= window.config.user.speed.value * musicSpeedMultiplier * 2
-        }
-
-        if (window.config.effects.colorShift.value) {
-          obj.myMaterial.color.setHSL(this.hueValues[obj.mySubset]!, this.saturation, DEF_BRIGHTNESS)
-        }
       }
 
-      if (obj.position.z > window.config.user.scaleFactor.value / 2) {
-        obj.position.setZ(-(this.levels - 1) * this.levelDepth + this.levelDepth)
+      this.applyParticleMotion(obj, count, musicSpeedMultiplier, wasAudioPeak)
+
+      // An orbit fade's outgoing objects should keep drifting/rotating/color-shifting just
+      // like they would have without the fade -- only their shape and opacity differ from the
+      // incoming set, so they get the same per-frame motion, paired by index.
+      const outgoingObj = this.orbitFade?.outgoing[index]
+      if (outgoingObj) {
+        this.applyParticleMotion(outgoingObj, count, musicSpeedMultiplier, wasAudioPeak)
       }
 
-      if (window.config.effects.cyclone.value) {
-        if (count % 3 === 0) {
-          obj.rotation.z += (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
-        } else if (count % 3 === 1) {
-          obj.rotation.z -= (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
-        }
-      } else {
-        obj.rotation.z += (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
-      }
       count++
     })
+  }
+
+  private applyParticleMotion(obj: ParticleSystem, count: number, musicSpeedMultiplier: number, applyPeakEffects: boolean): void {
+    obj.position.z += window.config.user.speed.value * musicSpeedMultiplier
+
+    if (applyPeakEffects) {
+      if (window.config.effects.wobWob.value) {
+        obj.position.z -= window.config.user.speed.value * musicSpeedMultiplier * 2
+      }
+
+      if (window.config.effects.colorShift.value) {
+        obj.myMaterial.color.setHSL(this.hueValues[obj.mySubset]!, this.saturation, DEF_BRIGHTNESS)
+      }
+    }
+
+    if (obj.position.z > window.config.user.scaleFactor.value / 2) {
+      obj.position.setZ(-(this.levels - 1) * this.levelDepth + this.levelDepth)
+    }
+
+    if (window.config.effects.cyclone.value) {
+      if (count % 3 === 0) {
+        obj.rotation.z += (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
+      } else if (count % 3 === 1) {
+        obj.rotation.z -= (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
+      }
+    } else {
+      obj.rotation.z += (window.config.user.rotationSpeed.value / 1000) * musicSpeedMultiplier
+    }
   }
 
   getScene(): THREE.Scene {

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -51,6 +51,10 @@ export class HopalongVisualizer {
   lastOrbitParams: { a: number | null; b: number | null; c: number | null; d: number | null; e: number | null; scaleFactor: number | null }
   orbit: { subsets: SubsetPoint[][]; xMin: number; xMax: number; yMin: number; yMax: number; scaleX: number; scaleY: number }
   private updateInterval: ReturnType<typeof setInterval> | undefined
+  /** Set once this visualizer becomes the outgoing half of a crossfade, so it stops reshaping
+   * its orbit from window.config (already overwritten with the incoming preset's values by the
+   * time the fade starts) and just fades out its last known shape instead. */
+  private frozen: boolean
 
   private onVideoClipsRestored = (event: Event): void => {
     const ce = event as CustomEvent<{ clips: string[] }>
@@ -86,6 +90,7 @@ export class HopalongVisualizer {
     this.lastOrbitParams = { a: null, b: null, c: null, d: null, e: null, scaleFactor: null }
     this.orbit = { subsets: [], xMin: 0, xMax: 0, yMin: 0, yMax: 0, scaleX: 0, scaleY: 0 }
     this.updateInterval = undefined
+    this.frozen = false
 
     for (let i = 0; i < this.layers; i++) {
       const subsetPoints: SubsetPoint[] = []
@@ -237,7 +242,7 @@ export class HopalongVisualizer {
           this.peakCountdown = 100
         }
 
-        if (count % 2 === 0 && window.config.effects.switcheroo.value) {
+        if (count % 2 === 0 && window.config.effects.switcheroo.value && !this.frozen) {
           if (!switcherooGenerated) {
             this.generateOrbit()
             switcherooGenerated = true
@@ -282,6 +287,8 @@ export class HopalongVisualizer {
   }
 
   updateOrbit(): void {
+    if (this.frozen) return
+
     const newA = window.config.orbit.a.value
     const newB = window.config.orbit.b.value
     const newC = window.config.orbit.c.value
@@ -413,6 +420,17 @@ export class HopalongVisualizer {
     if (this.updateInterval !== undefined) clearInterval(this.updateInterval)
     this.disposeVideoPlane()
     this.disposeScene(this.scene)
+  }
+
+  /** Stops this visualizer from reacting to further config changes -- called on the outgoing
+   * side of a crossfade, which should only fade out, not reshape itself around whatever preset
+   * is now live in window.config. */
+  freezeConfig(): void {
+    this.frozen = true
+    if (this.updateInterval !== undefined) {
+      clearInterval(this.updateInterval)
+      this.updateInterval = undefined
+    }
   }
 
   disposeVideoPlane(): void {

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -4,7 +4,6 @@ import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analys
 import { getResolvedSpriteUrl } from '../utils/spriteCache'
 import { acquireSpriteTexture, releaseSpriteTexture } from '../utils/textureCache'
 import { PARTICLE_CROSSFADE_DURATION_MS, MAX_CROSSFADE_GENERATIONS } from '../config/visualizer.config'
-import { easeInQuad } from '../utils/easing'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
@@ -421,13 +420,13 @@ export class HopalongVisualizer {
   private advanceOrbitFade(deltaTime: number): void {
     if (this.orbitIncomingElapsedMs < PARTICLE_CROSSFADE_DURATION_MS) {
       this.orbitIncomingElapsedMs = Math.min(PARTICLE_CROSSFADE_DURATION_MS, this.orbitIncomingElapsedMs + deltaTime)
-      this.setObjectsOpacity(this.objects, easeInQuad(this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS))
+      this.setObjectsOpacity(this.objects, this.orbitIncomingElapsedMs / PARTICLE_CROSSFADE_DURATION_MS)
     }
 
     this.orbitFades = this.orbitFades.filter((fade) => {
       fade.elapsedMs += deltaTime
       const t = Math.min(1, fade.elapsedMs / fade.durationMs)
-      this.setObjectsOpacity(fade.outgoing, easeInQuad(1 - t))
+      this.setObjectsOpacity(fade.outgoing, 1 - t)
       if (t < 1) return true
       this.finalizeOutgoingOrbitFade(fade)
       return false

--- a/src/visualization/hopalong-visualizer.ts
+++ b/src/visualization/hopalong-visualizer.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three'
 import { AudioAnalysedDataForVisualization } from '../audioanalysis/audio-analysed-data'
 import { getResolvedSpriteUrl } from '../utils/spriteCache'
 import { acquireSpriteTexture, releaseSpriteTexture } from '../utils/textureCache'
+import { PARTICLE_CROSSFADE_DURATION_MS } from '../config/visualizer.config'
 
 /*
  * ORIGINAL AUTHOR: Iacopo Sassarini
@@ -23,7 +24,18 @@ type ParticleSystem = THREE.Points & {
   myMaterial: THREE.PointsMaterial
   myLevel: number
   mySubset: number
+  /** Raw sprite entry (e.g. 'galaxySprite.png') this object was built with, so an orbit-shape
+   * crossfade can rebuild an equivalent object without re-deriving the round-robin sprite index. */
+  mySpriteUrl: string
   needsUpdate: number
+}
+
+/** In-flight opacity crossfade between an orbit-shape change's old and new particle objects,
+ * scoped to a single visualizer -- see startOrbitFade(). */
+type OrbitFade = {
+  outgoing: ParticleSystem[]
+  elapsedMs: number
+  durationMs: number
 }
 
 export class HopalongVisualizer {
@@ -55,6 +67,7 @@ export class HopalongVisualizer {
    * its orbit from window.config (already overwritten with the incoming preset's values by the
    * time the fade starts) and just fades out its last known shape instead. */
   private frozen: boolean
+  private orbitFade: OrbitFade | null
 
   private onVideoClipsRestored = (event: Event): void => {
     const ce = event as CustomEvent<{ clips: string[] }>
@@ -91,6 +104,7 @@ export class HopalongVisualizer {
     this.orbit = { subsets: [], xMin: 0, xMax: 0, yMin: 0, yMax: 0, scaleX: 0, scaleY: 0 }
     this.updateInterval = undefined
     this.frozen = false
+    this.orbitFade = null
 
     for (let i = 0; i < this.layers; i++) {
       const subsetPoints: SubsetPoint[] = []
@@ -125,7 +139,8 @@ export class HopalongVisualizer {
         const geometry = new THREE.BufferGeometry().setFromPoints(points)
 
         particleIndex = count % this.sprites.length
-        const sprite = acquireSpriteTexture(getResolvedSpriteUrl(this.sprites[particleIndex]!))
+        const spriteUrl = this.sprites[particleIndex]!
+        const sprite = acquireSpriteTexture(getResolvedSpriteUrl(spriteUrl))
         const material = new THREE.PointsMaterial({
           size: this.particleSize,
           map: sprite,
@@ -138,6 +153,7 @@ export class HopalongVisualizer {
         particles.myMaterial = material
         particles.myLevel = level
         particles.mySubset = s
+        particles.mySpriteUrl = spriteUrl
         particles.position.x = 0
         particles.position.y = 0
         particles.position.z = -this.levelDepth * level - (s * this.levelDepth / this.layers) + window.config.user.scaleFactor.value / 2
@@ -211,6 +227,8 @@ export class HopalongVisualizer {
   }
 
   update(deltaTime: number, audioData: AudioAnalysedDataForVisualization): void {
+    this.advanceOrbitFade(deltaTime)
+
     if (this.videoPlane) {
       const key = this.computeVideoPlaneSizeKey()
       if (key !== this.lastVideoPlaneSizeKey) {
@@ -305,8 +323,6 @@ export class HopalongVisualizer {
 
     if (!paramsChanged) return
 
-    const prevScaleFactor = this.lastOrbitParams.scaleFactor
-
     this.lastOrbitParams = { a: newA, b: newB, c: newC, d: newD, e: newE, scaleFactor: newScaleFactor }
 
     this.generateOrbit()
@@ -315,22 +331,84 @@ export class HopalongVisualizer {
       this.hueValues[s] = Math.random()
     }
 
-    this.objects.forEach((obj) => {
+    this.startOrbitFade()
+  }
+
+  /**
+   * Orbit param changes used to overwrite the existing particle objects' position buffers
+   * directly, snapping to the new shape in one frame -- same jarring "instant jump" the particle
+   * crossfade (HopalongManager.startCrossfade()) was built to avoid for Particle Config changes.
+   * This applies the identical double-buffer opacity technique, just scoped to this visualizer's
+   * own objects instead of swapping the whole visualizer: build a parallel set of objects at the
+   * new orbit shape (this.orbit.subsets was just regenerated above), fade the old set out and the
+   * new set in, then dispose the old set. New objects inherit the outgoing object's *current*
+   * position/rotation (not the spawn formula) so there's no additional depth/rotation jump on
+   * top of the shape change.
+   */
+  private startOrbitFade(): void {
+    if (this.orbitFade) {
+      // Another orbit param change landed mid-fade -- finish it immediately rather than
+      // stacking a second outgoing generation (same cap-at-2 pattern as the particle crossfade).
+      this.setObjectsOpacity(this.objects, 1)
+      this.finalizeOrbitFade()
+    }
+
+    const outgoing = this.objects
+    const incoming: ParticleSystem[] = outgoing.map((obj) => {
       const currentSubset = this.orbit.subsets[obj.mySubset]!
-      const posArray = obj.geometry.attributes.position!.array as Float32Array
-      for (let i = 0; i < this.particlesPerLayer; i++) {
-        posArray[i * 3] = currentSubset[i]!.vertex.x
-        posArray[i * 3 + 1] = currentSubset[i]!.vertex.y
-      }
-      obj.geometry.attributes.position!.needsUpdate = true
+      const geometry = new THREE.BufferGeometry().setFromPoints(currentSubset.map((point) => point.vertex))
+      const sprite = acquireSpriteTexture(getResolvedSpriteUrl(obj.mySpriteUrl))
+      const material = new THREE.PointsMaterial({
+        size: this.particleSize,
+        map: sprite,
+        blending: THREE.AdditiveBlending,
+        depthTest: false,
+        transparent: true,
+        opacity: 0
+      })
+
+      const particles = new THREE.Points(geometry, material) as ParticleSystem
+      particles.myMaterial = material
+      particles.myLevel = obj.myLevel
+      particles.mySubset = obj.mySubset
+      particles.mySpriteUrl = obj.mySpriteUrl
+      particles.position.copy(obj.position)
+      particles.rotation.z = obj.rotation.z
+      particles.needsUpdate = 0
+      particles.myMaterial.color.setHSL(this.hueValues[obj.mySubset]!, this.saturation, DEF_BRIGHTNESS)
+      this.scene.add(particles)
+      return particles
     })
 
-    if (prevScaleFactor !== null && newScaleFactor !== prevScaleFactor) {
-      const dz = (newScaleFactor - prevScaleFactor) / 2
-      this.objects.forEach((obj) => {
-        obj.position.z += dz
-      })
-    }
+    this.objects = incoming
+    this.orbitFade = { outgoing, elapsedMs: 0, durationMs: PARTICLE_CROSSFADE_DURATION_MS }
+  }
+
+  private advanceOrbitFade(deltaTime: number): void {
+    const fade = this.orbitFade
+    if (!fade) return
+
+    fade.elapsedMs += deltaTime
+    const t = Math.min(1, fade.elapsedMs / fade.durationMs)
+    this.setObjectsOpacity(fade.outgoing, 1 - t)
+    this.setObjectsOpacity(this.objects, t)
+    if (t >= 1) this.finalizeOrbitFade()
+  }
+
+  private finalizeOrbitFade(): void {
+    const fade = this.orbitFade!
+    fade.outgoing.forEach((obj) => {
+      this.scene.remove(obj)
+      obj.geometry.dispose()
+      this.disposeMaterial(obj.myMaterial)
+    })
+    this.orbitFade = null
+  }
+
+  private setObjectsOpacity(objects: ParticleSystem[], opacity: number): void {
+    objects.forEach((obj) => {
+      obj.myMaterial.opacity = opacity
+    })
   }
 
   generateOrbit(): void {
@@ -424,12 +502,19 @@ export class HopalongVisualizer {
 
   /** Stops this visualizer from reacting to further config changes -- called on the outgoing
    * side of a crossfade, which should only fade out, not reshape itself around whatever preset
-   * is now live in window.config. */
+   * is now live in window.config. Also resolves any in-progress orbit-shape fade immediately:
+   * once HopalongManager starts driving this visualizer's overall opacity as a single outgoing
+   * generation, an unrelated inner fade still animating individual objects' opacity would fight
+   * it for control of the same materials. */
   freezeConfig(): void {
     this.frozen = true
     if (this.updateInterval !== undefined) {
       clearInterval(this.updateInterval)
       this.updateInterval = undefined
+    }
+    if (this.orbitFade) {
+      this.setObjectsOpacity(this.objects, 1)
+      this.finalizeOrbitFade()
     }
   }
 


### PR DESCRIPTION
## Summary
- #2 [stack: user-platform] (1/7) — Particle Config changes (and preset switches that touch particle settings) used to hard-reset the scene: `HopalongManager` destroyed the old particle system and constructed the new one synchronously on the same frame, producing a frame where particles were simply gone.
- `HopalongManager` now runs the outgoing and incoming `HopalongVisualizer` particle systems simultaneously (reparented into one live scene) and crossfades their opacity over a fixed 800ms duration before disposing the outgoing one. Both keep animating during the fade.
- Added `PARTICLE_CROSSFADE_DURATION_MS` to `src/config/visualizer.config.ts` (sub-task 3 — a later config-gear task makes this user-configurable).
- `ConfigProvider.tsx`'s `retrieveConfigPreset`/`resetConfig` needed no change (sub-task 4) — they already write straight to `window.config`, which `HopalongManager` polls every animation frame via `particleConfigChanged()`, the same mechanism every other config mutator in this codebase already relies on to reach the visualizer. Rationale detailed in `docs/stack-notes/user-platform.md`.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] Manual browser verification (temporary Playwright script, not committed): confirmed the crossfade runs the full 800ms with correctly complementary opacities (sampled mid-fade: outgoing 0.109 / incoming 0.891 at 713ms/800ms elapsed) and that repeated preset switches don't leak objects into the live scene.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core render loop, scene graph reparenting, and GPU texture lifecycle; mistakes could cause leaks, visual glitches, or incorrect disposal during rapid preset switches.
> 
> **Overview**
> **Particle config** changes (including preset switches) no longer call a synchronous full visualizer rebuild. `HopalongManager` keeps outgoing and incoming `HopalongVisualizer` instances alive together, reparents their particle `Points` into one scene, and crossfades opacity over `PARTICLE_CROSSFADE_DURATION_MS` (750ms). Outgoing generations are **frozen** so they do not follow the new `window.config`, and up to `MAX_CROSSFADE_GENERATIONS` overlapping fades are supported before the oldest is force-finished.
> 
> **Orbit parameter** changes in `HopalongVisualizer` use the same opacity crossfade pattern (new particle objects at the new shape, old set faded out) instead of snapping position buffers in one frame. Switcheroo and motion updates skip frozen/outgoing objects appropriately.
> 
> A new **refcounted** `textureCache` shares sprite textures across materials and crossfade generations, with async load failure fallback to `/fractaleye.png`. Disposal goes through `releaseSpriteTexture` instead of immediate `texture.dispose()`.
> 
> Stack notes in `docs/stack-notes/user-platform.md` document the old hard-reset path, why `ConfigProvider` did not need changes, and known limits (video plane and lights are not crossfaded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba7e10d4b84e6bdb218ccb1a16d9596a5eee926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Particle preset and orbit changes now transition smoothly through opacity crossfades instead of abrupt replacements.
  * Overlapping transitions are supported with a 750 ms fade and up to four active generations.
  * Particle sprite textures are shared and reused for improved loading efficiency.

* **Bug Fixes**
  * Failed sprite loads now use a bundled fallback image.
  * Unused textures and video resources are released automatically.

* **Documentation**
  * Added guidance covering crossfades, validation results, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->