### PR TITLE
chore: session housekeeping 2026-08-07

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -4,13 +4,6 @@ Instructions for agent: This file is the task inventory only. Workflow rules (br
 
 ## Agent-Ready
 
-- [ ] #18 [stack: solo] Auto-strip background from uploaded particle sprites.
-  - Acceptance: uploading a sprite with a black/gray/white background produces a stored/rendered sprite with that background removed via edge flood-fill (not a global per-pixel threshold); cutoff edges have soft alpha falloff; dark outlines/white highlights in the art interior are preserved.
-  - Sub-tasks: (1) Implement edge-inward flood-fill in `ParticleSpriteHud.tsx`'s `prepareSpriteDataUrl()`, alongside the existing resize step, before upload (client-side canvas pixel access is already in play there). (2) Apply distance-based alpha falloff near the flood-fill boundary instead of a hard cutoff. (3) Only flood-fill from near-neutral (black/gray/white) edge pixels, so colored backgrounds are left untouched. (4) Manually test with sample uploads (dark-outlined art, white-highlighted art) to confirm no holes are punched in interior details.
-  - NEEDS HUMAN: none anticipated; flag in the PR if flood-fill perf on up-to-512px sprites causes noticeable upload lag, as a follow-up rather than a blocker.
-- [ ] #2 [stack: user-platform] Add crossfade for preset switching. Transitions should never abruptly reset the scene. (stack order 2/7)
-  - Acceptance: switching presets visually crossfades; no frame where the scene hard-resets.
-  - Sub-tasks: (1) Confirm exact hard-reset trigger — Particle Config changes force a full re-render per README; crossfade must cover that regeneration, not just simple value changes. (2) Implement in `src/visualization/hopalong-manager.ts`: run old + new particle systems simultaneously for a fixed duration, fade opacity, then dispose the old one. (3) Add a default duration constant (e.g. in `src/config/visualizer.config.ts`) — made per-user configurable by the config-gear task below. (4) Wire `retrieveConfigPreset`/`resetConfig` in `src/components/config/context/ConfigProvider.tsx` (currently a hard `setConfig(next)`) through the crossfade path.
 - [ ] #3 [stack: user-platform] Create a `users` collection in Mongo keyed by `clerkId`. Clerk remains the source of truth for identity; this collection holds app data (settings, logo particle reference, display name cache, future entitlements). (stack order 3/7)
   - Creation: lazy-create on first authenticated request, plus Clerk `user.created`/`user.updated` webhook to sync display name and connected providers.
   - Investigate and document how the current Spotify and Google sign-ins surface display names in Clerk (native vs custom OAuth provider) and which field to cache.

--- a/docs/nightlight-meta.json
+++ b/docs/nightlight-meta.json
@@ -1,5 +1,5 @@
 {
   "nextTaskNumber": 21,
-  "tasksCompleted": 3,
+  "tasksCompleted": 5,
   "tasksBlocked": 0
 }

--- a/docs/tasks-archive/2026-08-07.md
+++ b/docs/tasks-archive/2026-08-07.md
@@ -1,0 +1,11 @@
+# Completed 2026-08-07
+
+- #18 [stack: solo] Auto-strip background from uploaded particle sprites.
+  PR: #154
+  Notes: Edge flood-fill background removal added to `prepareSpriteDataUrl` with soft alpha falloff; verified via synthetic pixel-grid tests, typecheck/lint/test/build all pass.
+  NEEDS HUMAN: none.
+
+- #2 [stack: user-platform] Add crossfade for preset switching. Transitions should never abruptly reset the scene.
+  PR: #155
+  Notes: Particle system now crossfades (800ms) on config/preset changes instead of hard-resetting; verified in-browser via temporary Playwright instrumentation.
+  NEEDS HUMAN: none.


### PR DESCRIPTION
## Summary
- Archives 2 completed tasks from this run's 2-task limit to `docs/tasks-archive/2026-08-07.md`
- Removes #18 and #2 from `TASKS.md` (both merged into open PRs, not yet merged to main)
- Updates `tasksCompleted` 3 -> 5 in `docs/nightlight-meta.json`

## Tasks this run
- #18 [stack: solo] Auto-strip background from uploaded particle sprites — PR #154 (open)
- #2 [stack: user-platform] Add crossfade for preset switching — PR #155 (open)

Tasks #3-#11, #19, #20 were out of scope this run (`--limit 2`) and left untouched in TASKS.md.

## Test plan
- [x] Confirmed PR #154 and #155 are open via `gh pr view`
- [x] No code changes — docs/tasks only, per housekeeping scope rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and task-tracking only; no runtime or API behavior changes.
> 
> **Overview**
> **Session housekeeping** for two agent-run tasks whose implementation lives in open PRs (#154 sprite background strip, #155 preset crossfade).
> 
> Removes **#18** and **#2** from the Agent-Ready list in `TASKS.md` and records them in new `docs/tasks-archive/2026-08-07.md` with PR links and short verification notes. Bumps `tasksCompleted` from **3 → 5** in `docs/nightlight-meta.json`. No application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bc7b86ac5e72356e3b2eb2a4da657dccb4b876. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->