### PR TITLE
feat(presets): add 1-9 hotkeys with badge indicator

### DIFF
--- a/src/components/presets/Presets.css
+++ b/src/components/presets/Presets.css
@@ -210,7 +210,7 @@
   background: #333;
   border: 1px solid #777;
   color: #ccc;
-  font-size: 0.65rem;
+  font-size: 0.9rem;
   font-weight: 600;
   line-height: 1;
   pointer-events: none;

--- a/src/components/presets/Presets.css
+++ b/src/components/presets/Presets.css
@@ -210,10 +210,14 @@
   background: #333;
   border: 1px solid #777;
   color: #ccc;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
   line-height: 1;
   pointer-events: none;
+}
+
+.preset-hotkey-badge-num {
+  transform: translateY(1px);
 }
 
 /* Pagination */

--- a/src/components/presets/Presets.css
+++ b/src/components/presets/Presets.css
@@ -197,6 +197,25 @@
   flex-shrink: 0;
 }
 
+.preset-hotkey-badge {
+  position: absolute;
+  top: -6px;
+  left: -6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  background: #333;
+  border: 1px solid #777;
+  color: #ccc;
+  font-size: 0.65rem;
+  font-weight: 600;
+  line-height: 1;
+  pointer-events: none;
+}
+
 /* Pagination */
 .presets-pagination {
   display: flex;

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { Row, Col } from 'react-bootstrap'
 import './Presets.css'
 
@@ -31,7 +31,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
   const [trialPresetKey, setTrialPresetKey] = useState<string | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const packMap = new Map(packs.map(p => [p.name, p]))
+  const packMap = useMemo(() => new Map(packs.map(p => [p.name, p])), [packs])
 
   const { startTrial, cancelTrial, modalVisible, trialPackName, secondsLeft, dismissTrial } = usePremiumTrial({
     config,
@@ -60,7 +60,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     onPackSelect?.(pack === 'All' ? '' : pack)
   }
 
-  const handlePresetClick = (preset: PresetMeta, event: PresetRetrieveEvent): void => {
+  const handlePresetClick = useCallback((preset: PresetMeta, event: PresetRetrieveEvent): void => {
     const packMeta = packMap.get(preset.pack)
     if (packMeta?.isPremium && !packMeta.isOwn) {
       setTrialPresetKey(preset.id ?? preset.name)
@@ -71,7 +71,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
       void retrieveConfigPreset(event)
     }
     onSelect?.({ name: preset.name, label: preset.label, pack: preset.pack, isOwn: preset.isOwn })
-  }
+  }, [packMap, startTrial, cancelTrial, retrieveConfigPreset, onSelect])
 
   useEffect(() => {
     // Popped-out config windows render this component into a separate window.open()
@@ -81,7 +81,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (ownerDocument.activeElement?.tagName === 'INPUT') return
       if (e.repeat) return
-      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
       if (modalVisible) return
       const activeMeta = packMap.get(activePack)
       if (activeMeta?.isPremium && !activeMeta.isOwn && !previewMode) return
@@ -96,7 +96,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     }
     ownerDocument.addEventListener('keydown', handleKeyDown)
     return () => ownerDocument.removeEventListener('keydown', handleKeyDown)
-  }, [visible, activePack, previewMode, modalVisible, packMap])
+  }, [visible, activePack, previewMode, modalVisible, packMap, handlePresetClick])
 
   return (
     <>

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { Row, Col } from 'react-bootstrap'
 import './Presets.css'
 
@@ -72,6 +72,23 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     onSelect?.({ name: preset.name, label: preset.label, pack: preset.pack, isOwn: preset.isOwn })
   }
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (document.activeElement?.tagName === 'INPUT') return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const hotkeyIndex = Number(e.key) - 1
+      if (!Number.isInteger(hotkeyIndex) || hotkeyIndex < 0 || hotkeyIndex > 8) return
+      const preset = visible[hotkeyIndex]
+      if (!preset) return
+      const event: PresetRetrieveEvent = {
+        currentTarget: { dataset: { name: String(preset.name), id: preset.id ?? '' } },
+      }
+      handlePresetClick(preset, event)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [visible])
+
   return (
     <>
       <Row>
@@ -105,7 +122,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
               ) : null
             })()}
             <div className={`presets-grid${expanded ? ' presets-grid--expanded' : ''}${paging ? ' paging' : ''}`}>
-              {visible.map((preset) => {
+              {visible.map((preset, index) => {
                 const { id, name, label, sprite } = preset
                 const event: PresetRetrieveEvent = {
                   currentTarget: { dataset: { name: String(name), id: id ?? '' } },
@@ -113,6 +130,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
                 const isTrialing = trialPresetKey === (id ?? name) && secondsLeft !== null
                 const presetPackMeta = packMap.get(preset.pack)
                 const isPremiumUnowned = presetPackMeta?.isPremium && !presetPackMeta.isOwn
+                const hotkey = index < 9 ? index + 1 : null
                 return (
                   <button
                     key={id ?? name}
@@ -121,6 +139,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
                     data-id={id ?? ''}
                     onClick={() => handlePresetClick(preset, event)}
                   >
+                    {hotkey !== null && <span className='preset-hotkey-badge'>{hotkey}</span>}
                     <img src={presetSpriteSrc(sprite)} alt='' className='preset-sprite' />
                     <span>{label}</span>
                     {isTrialing && <span className='preset-trial-countdown'>{secondsLeft}</span>}

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -144,7 +144,11 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
                     data-id={id ?? ''}
                     onClick={() => handlePresetClick(preset, event)}
                   >
-                    {hotkey !== null && <span className='preset-hotkey-badge'>{hotkey}</span>}
+                    {hotkey !== null && (
+                      <span className='preset-hotkey-badge'>
+                        <span className='preset-hotkey-badge-num'>{hotkey}</span>
+                      </span>
+                    )}
                     <img src={presetSpriteSrc(sprite)} alt='' className='preset-sprite' />
                     <span>{label}</span>
                     {isTrialing && <span className='preset-trial-countdown'>{secondsLeft}</span>}

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback, useEffect, useRef } from 'react'
 import { Row, Col } from 'react-bootstrap'
 import './Presets.css'
 
@@ -29,6 +29,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
   const [paging, setPaging] = useState(false)
   const [previewMode, setPreviewMode] = useState(false)
   const [trialPresetKey, setTrialPresetKey] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   const packMap = new Map(packs.map(p => [p.name, p]))
 
@@ -73,8 +74,12 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
   }
 
   useEffect(() => {
+    // Popped-out config windows render this component into a separate window.open()
+    // document, so the listener must attach to that document rather than the global
+    // one or hotkeys silently do nothing there.
+    const ownerDocument = containerRef.current?.ownerDocument ?? document
     const handleKeyDown = (e: KeyboardEvent): void => {
-      if (document.activeElement?.tagName === 'INPUT') return
+      if (ownerDocument.activeElement?.tagName === 'INPUT') return
       if (e.metaKey || e.ctrlKey || e.altKey) return
       const hotkeyIndex = Number(e.key) - 1
       if (!Number.isInteger(hotkeyIndex) || hotkeyIndex < 0 || hotkeyIndex > 8) return
@@ -85,15 +90,15 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
       }
       handlePresetClick(preset, event)
     }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    ownerDocument.addEventListener('keydown', handleKeyDown)
+    return () => ownerDocument.removeEventListener('keydown', handleKeyDown)
   }, [visible])
 
   return (
     <>
       <Row>
         <Col className={`presets-container${expanded ? ' presets-container--expanded' : ''}`}>
-          <div className='pack-tabs-row'>
+          <div ref={containerRef} className='pack-tabs-row'>
             <div className='pack-tabs'>
               {packNames.map(pack => {
                 const meta = packMap.get(pack)

--- a/src/components/presets/Presets.tsx
+++ b/src/components/presets/Presets.tsx
@@ -80,7 +80,11 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     const ownerDocument = containerRef.current?.ownerDocument ?? document
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (ownerDocument.activeElement?.tagName === 'INPUT') return
-      if (e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.repeat) return
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+      if (modalVisible) return
+      const activeMeta = packMap.get(activePack)
+      if (activeMeta?.isPremium && !activeMeta.isOwn && !previewMode) return
       const hotkeyIndex = Number(e.key) - 1
       if (!Number.isInteger(hotkeyIndex) || hotkeyIndex < 0 || hotkeyIndex > 8) return
       const preset = visible[hotkeyIndex]
@@ -92,7 +96,7 @@ const PresetsInner = ({ retrieveConfigPreset, revertConfig, config, presets, pac
     }
     ownerDocument.addEventListener('keydown', handleKeyDown)
     return () => ownerDocument.removeEventListener('keydown', handleKeyDown)
-  }, [visible])
+  }, [visible, activePack, previewMode, modalVisible, packMap])
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Pressing 1-9 now switches to the corresponding preset among the first 9 presets currently visible for the selected pack (respects pack filtering/pagination via the existing `visible` list in `Presets.tsx`)
- Hotkey presses route through the existing `handlePresetClick` path, so premium-pack trial gating still applies
- Ignores keypresses while an `<input>` is focused and ignores modifier-key combos
- Each of the first 9 preset items now shows a small numbered badge (`.preset-hotkey-badge`) in its top-left corner indicating the assigned hotkey

This is a first pass with a fixed/positional mapping (first 9 visible presets → keys 1-9). Full user-configurable hotkey assignment is tracked as future work.

## Test plan
- [x] `yarn typecheck` passes
- [x] `eslint` on changed files passes
- [ ] Manually verify in `yarn dev`: select a pack, confirm badges 1-9 appear on the first 9 presets, and pressing 1-9 loads the matching preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added numeric keyboard shortcuts for selecting the first nine visible presets.
  - Displayed shortcut badges on preset items to identify available keys.
  - Shortcuts are disabled while typing in input fields, using modifier keys, viewing modals, or accessing unavailable premium packs.
  - Shortcut handling also works in popped-out windows and cleans up automatically when no longer active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->